### PR TITLE
Java 21 support for Minecraft

### DIFF
--- a/java/curseforge/egg-curse-forge-generic.json
+++ b/java/curseforge/egg-curse-forge-generic.json
@@ -18,7 +18,8 @@
         "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java $([[ -f user_jvm_args.txt ]] && printf %s \"@user_jvm_args.txt\") -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true $([[ ! -f unix_args.txt ]] && printf %s \"-jar `cat .serverjar`\" || printf %s \"@unix_args.txt\")",

--- a/java/curseforge/egg-curse-forge-generic.json
+++ b/java/curseforge/egg-curse-forge-generic.json
@@ -19,7 +19,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java $([[ -f user_jvm_args.txt ]] && printf %s \"@user_jvm_args.txt\") -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true $([[ ! -f unix_args.txt ]] && printf %s \"-jar `cat .serverjar`\" || printf %s \"@unix_args.txt\")",

--- a/java/fabric/egg-fabric.json
+++ b/java/fabric/egg-fabric.json
@@ -19,7 +19,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/fabric/egg-fabric.json
+++ b/java/fabric/egg-fabric.json
@@ -18,7 +18,8 @@
         "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/folia/egg-folia.json
+++ b/java/folia/egg-folia.json
@@ -14,9 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 21": "ghcr.io\/pterodactyl\/yolks:java_21",
+        "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8",
+        "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
+        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/forge/forge/egg-forge-enhanced.json
+++ b/java/forge/forge/egg-forge-enhanced.json
@@ -19,7 +19,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true $( [[  ! -f unix_args.txt ]] && printf %s \"-jar {{SERVER_JARFILE}}\" || printf %s \"@unix_args.txt\" )",

--- a/java/forge/forge/egg-forge-enhanced.json
+++ b/java/forge/forge/egg-forge-enhanced.json
@@ -18,7 +18,8 @@
         "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true $( [[  ! -f unix_args.txt ]] && printf %s \"-jar {{SERVER_JARFILE}}\" || printf %s \"@unix_args.txt\" )",

--- a/java/ftb/egg-ftb-modpacksch-server.json
+++ b/java/ftb/egg-ftb-modpacksch-server.json
@@ -19,7 +19,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -javaagent:log4jfix\/Log4jPatcher-1.0.0.jar -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true $( [[  ! -f unix_args.txt ]] && printf %s \"-jar start-server.jar\" || printf %s \"@unix_args.txt\" )",

--- a/java/ftb/egg-ftb-modpacksch-server.json
+++ b/java/ftb/egg-ftb-modpacksch-server.json
@@ -18,7 +18,8 @@
         "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -javaagent:log4jfix\/Log4jPatcher-1.0.0.jar -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true $( [[  ! -f unix_args.txt ]] && printf %s \"-jar start-server.jar\" || printf %s \"@unix_args.txt\" )",

--- a/java/glowstone/egg-glowstone.json
+++ b/java/glowstone/egg-glowstone.json
@@ -14,7 +14,8 @@
         "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms768M -Xmx{{SERVER_MEMORY}}M -XX:+UseG1GC -jar {{SERVER_JARFILE}}",

--- a/java/glowstone/egg-glowstone.json
+++ b/java/glowstone/egg-glowstone.json
@@ -15,7 +15,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms768M -Xmx{{SERVER_MEMORY}}M -XX:+UseG1GC -jar {{SERVER_JARFILE}}",

--- a/java/krypton/egg-krypton.json
+++ b/java/krypton/egg-krypton.json
@@ -14,11 +14,12 @@
     "pid_limit"
 ],
 "docker_images": {
-  "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8",
-  "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
-  "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
-  "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-  "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+    "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8",
+    "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
+    "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
+    "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
+    "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+    "Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
 },
   "file_denylist": "",
   "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JAR}}",

--- a/java/krypton/egg-krypton.json
+++ b/java/krypton/egg-krypton.json
@@ -19,7 +19,7 @@
     "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
     "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
     "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-    "Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+    "Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
 },
   "file_denylist": "",
   "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JAR}}",

--- a/java/limbo/egg-limbo.json
+++ b/java/limbo/egg-limbo.json
@@ -10,7 +10,12 @@
     "description": "Standalone server program Limbo.",
     "features": null,
     "docker_images": {
-        "ghcr.io\/pterodactyl\/yolks:java_17": "ghcr.io\/pterodactyl\/yolks:java_17"
+        "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8",
+        "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
+        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
+        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}",

--- a/java/limbo/egg-limbo.json
+++ b/java/limbo/egg-limbo.json
@@ -15,7 +15,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}",

--- a/java/magma/egg-magma.json
+++ b/java/magma/egg-magma.json
@@ -19,7 +19,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}",

--- a/java/magma/egg-magma.json
+++ b/java/magma/egg-magma.json
@@ -18,7 +18,8 @@
         "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}",

--- a/java/modrinth/egg-modrinth-generic.json
+++ b/java/modrinth/egg-modrinth-generic.json
@@ -17,7 +17,9 @@
         "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8",
         "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
-        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17"
+        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java $([[ -f user_jvm_args.txt ]] && printf %s \"@user_jvm_args.txt\") -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true $([[ ! -f unix_args.txt ]] && printf %s \"-jar `cat .serverjar`\" || printf %s \"@unix_args.txt\")",

--- a/java/modrinth/egg-modrinth-generic.json
+++ b/java/modrinth/egg-modrinth-generic.json
@@ -19,7 +19,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java $([[ -f user_jvm_args.txt ]] && printf %s \"@user_jvm_args.txt\") -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true $([[ ! -f unix_args.txt ]] && printf %s \"-jar `cat .serverjar`\" || printf %s \"@unix_args.txt\")",

--- a/java/mohist/egg-mohist.json
+++ b/java/mohist/egg-mohist.json
@@ -14,11 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
-        "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
         "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
+        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
+        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/mohist/egg-mohist.json
+++ b/java/mohist/egg-mohist.json
@@ -19,7 +19,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/neoforge/egg-neo-forge.json
+++ b/java/neoforge/egg-neo-forge.json
@@ -14,10 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
+        "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8",
         "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
-        "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8"
+        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
+        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true @unix_args.txt",

--- a/java/neoforge/egg-neo-forge.json
+++ b/java/neoforge/egg-neo-forge.json
@@ -19,7 +19,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true @unix_args.txt",

--- a/java/paper/egg-paper.json
+++ b/java/paper/egg-paper.json
@@ -19,7 +19,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-        "Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/paper/egg-paper.json
+++ b/java/paper/egg-paper.json
@@ -19,7 +19,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/purpur/egg-purpur.json
+++ b/java/purpur/egg-purpur.json
@@ -19,7 +19,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-        "Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java --add-modules=jdk.incubator.vector -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/quilt/egg-quilt.json
+++ b/java/quilt/egg-quilt.json
@@ -10,11 +10,12 @@
     "description": "The Quilt project is an open-source, community-driven modding toolchain designed primarily for Minecraft. By focusing on speed, ease of use and modularity, Quilt aims to provide a sleek and modern modding toolchain with an open ecosystem.",
     "features": null,
     "docker_images": {
-        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8",
         "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}} nogui",

--- a/java/quilt/egg-quilt.json
+++ b/java/quilt/egg-quilt.json
@@ -15,7 +15,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}} nogui",

--- a/java/spigot/egg-spigot.json
+++ b/java/spigot/egg-spigot.json
@@ -19,7 +19,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/spigot/egg-spigot.json
+++ b/java/spigot/egg-spigot.json
@@ -18,7 +18,8 @@
         "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/spongeforge/egg-sponge-forge.json
+++ b/java/spongeforge/egg-sponge-forge.json
@@ -19,7 +19,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/spongeforge/egg-sponge-forge.json
+++ b/java/spongeforge/egg-sponge-forge.json
@@ -18,7 +18,8 @@
         "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/spongevanilla/egg-sponge-vanilla.json
+++ b/java/spongevanilla/egg-sponge-vanilla.json
@@ -14,10 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
+        "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8",
         "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
-        "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8"
+        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
+        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/spongevanilla/egg-sponge-vanilla.json
+++ b/java/spongevanilla/egg-sponge-vanilla.json
@@ -19,7 +19,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/technic/Tekkit-2/egg-tekkit-2.json
+++ b/java/technic/Tekkit-2/egg-tekkit-2.json
@@ -18,7 +18,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -server  -Xms128M -Xmx{{SERVER_MEMORY}}M -Dfml.queryResult=confirm -jar forge.jar nogui",

--- a/java/technic/Tekkit-2/egg-tekkit-2.json
+++ b/java/technic/Tekkit-2/egg-tekkit-2.json
@@ -13,8 +13,12 @@
         "java_version"
     ],
     "docker_images": {
-        "Java8": "ghcr.io\/pterodactyl\/yolks:java_8",
-        "Java11": "ghcr.io\/pterodactyl\/yolks:java_11"
+        "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8",
+        "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
+        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
+        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -server  -Xms128M -Xmx{{SERVER_MEMORY}}M -Dfml.queryResult=confirm -jar forge.jar nogui",

--- a/java/technic/Tekkit/egg-tekkit.json
+++ b/java/technic/Tekkit/egg-tekkit.json
@@ -16,7 +16,8 @@
         "ghcr.io\/pterodactyl\/yolks:java_8",
         "ghcr.io\/pterodactyl\/yolks:java_11",
         "ghcr.io\/pterodactyl\/yolks:java_16",
-        "ghcr.io\/pterodactyl\/yolks:java_17"
+        "ghcr.io\/pterodactyl\/yolks:java_17",
+		"ghcr.io\/pterodactyl\/yolks:java:21"
     ],
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar Tekkit.jar",

--- a/java/technic/tekkit-classic/egg-tekkit-classic.json
+++ b/java/technic/tekkit-classic/egg-tekkit-classic.json
@@ -16,7 +16,8 @@
         "ghcr.io\/pterodactyl\/yolks:java_8",
         "ghcr.io\/pterodactyl\/yolks:java_11",
         "ghcr.io\/pterodactyl\/yolks:java_16",
-        "ghcr.io\/pterodactyl\/yolks:java_17"
+        "ghcr.io\/pterodactyl\/yolks:java_17",
+		"ghcr.io\/pterodactyl\/yolks:java_21"
     ],
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar Tekkit.jar",

--- a/java/vanillacord/egg-vanilla-cord.json
+++ b/java/vanillacord/egg-vanilla-cord.json
@@ -19,7 +19,7 @@
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
+		"Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/vanillacord/egg-vanilla-cord.json
+++ b/java/vanillacord/egg-vanilla-cord.json
@@ -18,7 +18,8 @@
         "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+		"Java 18": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",


### PR DESCRIPTION
Added Java 21 to the Minecraft Eggs that needs it by adding the Java 21 Yolk to each egg file.