### PR TITLE
Create egg-bungeecord.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ It’s set in infinitely-generated worlds of wide open terrain - icy mountains, 
   * [Velocity](proxy/java/velocity)
   * [VIAaas](proxy/java/viaaas)
   * [Waterfall](proxy/java/waterfall)
+  * [Bungeecord](proxy/java/Bungeecord)

--- a/proxy/Bungeecord/egg-bungeecord.json
+++ b/proxy/Bungeecord/egg-bungeecord.json
@@ -1,0 +1,60 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v2",
+        "update_url": null
+    },
+    "exported_at": "2024-05-08T20:10:12+02:00",
+    "name": "Bungeecord",
+    "author": "support@pterodactyl.io",
+    "description": "For a long time, Minecraft server owners have had a dream that encompasses a free, easy, and reliable way to connect multiple Minecraft servers together. BungeeCord is the answer to said dream. Whether you are a small server wishing to string multiple game-modes together, or the owner of the ShotBow Network, BungeeCord is the ideal solution for you. With the help of BungeeCord, you will be able to unlock your community's full potential.",
+    "features": [
+        "eula",
+        "java_version",
+        "pid_limit"
+    ],
+    "docker_images": {
+        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
+        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
+        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
+        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
+        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21"
+    },
+    "file_denylist": [],
+    "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}",
+    "config": {
+        "files": "{\r\n    \"config.yml\": {\r\n        \"parser\": \"yaml\",\r\n        \"find\": {\r\n            \"listeners[0].query_port\": \"{{server.build.default.port}}\",\r\n            \"listeners[0].host\": \"0.0.0.0:{{server.build.default.port}}\",\r\n            \"servers.*.address\": {\r\n                \"regex:^(127\\\\.0\\\\.0\\\\.1|localhost)(:\\\\d{1,5})?$\": \"{{config.docker.interface}}$2\"\r\n            }\r\n        }\r\n    }\r\n}",
+        "startup": "{\r\n    \"done\": \"Listening on \"\r\n}",
+        "logs": "{}",
+        "stop": "end"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/ash\r\n# Bungeecord Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n\r\ncd \/mnt\/server\r\n\r\nif [ -z \"${BUNGEE_VERSION}\" ] || [ \"${BUNGEE_VERSION}\" == \"latest\" ]; then\r\n    BUNGEE_VERSION=\"lastStableBuild\"\r\nfi\r\n\r\ncurl -o ${SERVER_JARFILE} https:\/\/ci.md-5.net\/job\/BungeeCord\/${BUNGEE_VERSION}\/artifact\/bootstrap\/target\/BungeeCord.jar",
+            "container": "ghcr.io\/parkervcp\/installers:alpine",
+            "entrypoint": "ash"
+        }
+    },
+    "variables": [
+        {
+            "name": "Bungeecord Version",
+            "description": "The version of Bungeecord to download and use.",
+            "env_variable": "BUNGEE_VERSION",
+            "default_value": "latest",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|alpha_num|between:1,6",
+            "field_type": "text"
+        },
+        {
+            "name": "Bungeecord Jar File",
+            "description": "The name of the Jarfile to use when running Bungeecord.",
+            "env_variable": "SERVER_JARFILE",
+            "default_value": "bungeecord.jar",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|regex:\/^([\\w\\d._-]+)(\\.jar)$\/",
+            "field_type": "text"
+        }
+    ]
+}

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -5,6 +5,7 @@
   * [Velocity](/game_eggs/minecraft/proxy/java/velocity)
   * [VIAaaS](/game_eggs/minecraft/proxy/java/viaaas)
   * [Waterfall](/game_eggs/minecraft/proxy/java/waterfall)
+  * [Bungeecord](/game_eggs/minecraft/proxy/java/Bungeecord)
 * [Bedrock](/game_eggs/minecraft/proxy/bedrock)
   * [Waterdog PE](/game_eggs/minecraft/proxy/bedrock/waterdogpe)
 * [Cross Platform](/game_eggs/minecraft/proxy/cross_platform)


### PR DESCRIPTION
Change in code:
- Added Bungeecord
- Added Java 21
- all `ghcr.io\/pterodactyl\/yolks:` are replaced by: `ghcr.io\/parkervcp\/yolks:`
- modify code respecting the code of `parkervcp`

# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [ ] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [ ] The egg was exported from the panel

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->

## New egg Submissions

1. [x] Does your submission pass tests (server is connectable)?
2. [ ] Does your egg use a custom docker image?
    * [ ] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?
3. [ ] Have you added the egg to the main README.md and any other README files in subdirectories of the egg (e.g /game_eggs) according to the alphabetical order?
4. [ ] Have you added a unique README.md for the egg you are adding according to the alphabetical order?
5. [ ] You verify that the start command applied does not use a shell script
    * [ ] If some script is needed then it is part of a current yolk or a PR to add one
6. [x] The egg was exported from the panel