### PR TITLE
[Bedrock Vanilla] Add Multiple World choose options

### DIFF
--- a/bedrock/bedrock/egg-pterodactyl-vanilla-bedrock.json
+++ b/bedrock/bedrock/egg-pterodactyl-vanilla-bedrock.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-09-24T13:43:28-07:00",
+    "exported_at": "2025-03-28T16:22:19+06:00",
     "name": "Vanilla Bedrock",
     "author": "parker@parkervcp.com",
     "description": "Bedrock Edition (also known as the Bedrock Version, Bedrock Codebase, Bedrock Engine or just Bedrock) refers to the multi-platform family of editions of Minecraft developed by Mojang AB, Microsoft Studios, 4J Studios, and SkyBox Labs. Prior to this term, as the engine originated with Pocket Edition, this entire product family was referred to as \"Pocket Edition\", \"MCPE\", or \"Pocket\/Windows 10 Edition\".",
@@ -17,7 +17,7 @@
     "file_denylist": [],
     "startup": ".\/bedrock_server",
     "config": {
-        "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"server-name\": \"{{server.build.env.SERVERNAME}}\",\r\n            \"gamemode\": \"{{server.build.env.GAMEMODE}}\",\r\n            \"difficulty\": \"{{server.build.env.DIFFICULTY}}\",\r\n            \"allow-cheats\": \"{{server.build.env.CHEATS}}\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"server-name\": \"{{server.build.env.SERVERNAME}}\",\r\n            \"gamemode\": \"{{server.build.env.GAMEMODE}}\",\r\n            \"difficulty\": \"{{server.build.env.DIFFICULTY}}\",\r\n            \"level-name\": \"{{server.build.env.WORLDNAME}}\",\r\n            \"allow-cheats\": \"{{server.build.env.CHEATS}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Server started\"\r\n}",
         "logs": "{}",
         "stop": "stop"
@@ -88,6 +88,16 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|in:true,false",
+            "field_type": "text"
+        },
+        {
+            "name": "Choose World",
+            "description": "If you have multiple world files, Enter the World Folder Name you want to Select to Start the Server",
+            "env_variable": "WORLDNAME",
+            "default_value": "default",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:100",
             "field_type": "text"
         }
     ]

--- a/bedrock/bedrock/egg-vanilla-bedrock.json
+++ b/bedrock/bedrock/egg-vanilla-bedrock.json
@@ -1,14 +1,15 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "version": "PTDL_v2",
+        "version": "PLCN_v1",
         "update_url": null
     },
-    "exported_at": "2024-09-25T01:03:44+00:00",
+    "exported_at": "2025-03-29T08:45:01+00:00",
     "name": "Vanilla Bedrock",
     "author": "parker@parkervcp.com",
     "uuid": "a03036b8-8c1b-4c8a-80be-018baad3dcaf",
     "description": "Bedrock Edition (also known as the Bedrock Version, Bedrock Codebase, Bedrock Engine or just Bedrock) refers to the multi-platform family of editions of Minecraft developed by Mojang AB, Microsoft Studios, 4J Studios, and SkyBox Labs. Prior to this term, as the engine originated with Pocket Edition, this entire product family was referred to as \"Pocket Edition\", \"MCPE\", or \"Pocket\/Windows 10 Edition\".",
+    "tags": [],
     "features": [
         "pid_limit"
     ],
@@ -18,7 +19,7 @@
     "file_denylist": [],
     "startup": ".\/bedrock_server",
     "config": {
-        "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-port\": \"{{server.allocations.default.port}}\",\r\n            \"server-name\": \"{{server.environment.SERVERNAME}}\",\r\n            \"gamemode\": \"{{server.environment.GAMEMODE}}\",\r\n            \"difficulty\": \"{{server.environment.DIFFICULTY}}\",\r\n            \"allow-cheats\": \"{{server.environment.CHEATS}}\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-port\": \"{{server.allocations.default.port}}\",\r\n            \"server-name\": \"{{server.environment.SERVERNAME}}\",\r\n            \"gamemode\": \"{{server.environment.GAMEMODE}}\",\r\n            \"difficulty\": \"{{server.environment.DIFFICULTY}}\",\r\n            \"level-name\": \"{{server.environment.WORLDNAME}}\",\r\n            \"allow-cheats\": \"{{server.environment.CHEATS}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Server started\"\r\n}",
         "logs": "{}",
         "stop": "stop"
@@ -32,70 +33,102 @@
     },
     "variables": [
         {
-            "sort": 1,
             "name": "Bedrock Version",
             "description": "The version of bedrock. (Ex. 1.7.0.13)\r\n\r\nDefault version is latest.",
             "env_variable": "BEDROCK_VERSION",
             "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:20",
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "max:20"
+            ],
+            "sort": null
         },
         {
-            "sort": 2,
             "name": "ld lib path",
             "description": "Dumb reasons to need this",
             "env_variable": "LD_LIBRARY_PATH",
             "default_value": ".",
             "user_viewable": false,
             "user_editable": false,
-            "rules": "required|string|max:20",
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "max:20"
+            ],
+            "sort": null
         },
         {
-            "sort": 3,
             "name": "Server Name",
             "description": "The name for the server",
             "env_variable": "SERVERNAME",
             "default_value": "Bedrock Dedicated Server",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:50",
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "max:50"
+            ],
+            "sort": null
         },
         {
-            "sort": 4,
             "name": "Gamemode",
             "description": "Allowed values: \"survival\", \"creative\", or \"adventure\"",
             "env_variable": "GAMEMODE",
             "default_value": "survival",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|in:survival,creative,adventure",
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "in:survival,creative,adventure"
+            ],
+            "sort": null
         },
         {
-            "sort": 5,
             "name": "Difficulty",
             "description": "Allowed values: \"peaceful\", \"easy\", \"normal\", or \"hard\"",
             "env_variable": "DIFFICULTY",
             "default_value": "easy",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|in:peaceful,easy,normal,hard",
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "in:peaceful,easy,normal,hard"
+            ],
+            "sort": null
         },
         {
-            "sort": 6,
             "name": "Allow cheats",
             "description": "If true then cheats like commands can be used.\r\n\r\nAllowed values: \"true\" or \"false\"",
             "env_variable": "CHEATS",
             "default_value": "false",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|in:true,false",
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "in:true,false"
+            ],
+            "sort": null
+        },
+        {
+            "name": "Choose World",
+            "description": "If you have multiple world files, Enter the World Folder Name you want to Select to Start the Server",
+            "env_variable": "WORLDNAME",
+            "default_value": "default",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string",
+                "max:100"
+            ],
+            "sort": null
         }
     ]
 }


### PR DESCRIPTION
# Description

Added a Startup Variable Option which will point to the World Folder Name in the Directory and thus Choosing between Multiple Worlds more Easily

## Checklist for all submissions

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?

<!-- If this is an egg update fill these out -->

* [X] You verify that the start command applied does not use a shell script
* [X] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel