### PR TITLE
[java\curseforge] Improve API key documentation & visibility

### DIFF
--- a/java/curseforge/README.md
+++ b/java/curseforge/README.md
@@ -12,12 +12,12 @@ This can be found on the modpack page by clicking the wanted file and copying th
 The script will automatically setup of Forge, Fabric, or Quilt depending on the modpack.
 
 You *must* specify a CurseForge API key. 
-You can find out how to get an API key [here](https://support.curseforge.com/en/support/solutions/articles/9000208346-about-the-curseforge-api-and-how-to-apply-for-a-key)
+You can obtain an API key by creating a developer account [here](https://console.curseforge.com/) and then clicking on the "API keys" tab.
 
 ## Server Ports
 
 The minecraft server requires a single port for access (default 25565) but plugins may require extra ports to enabled for the server.
 
-| Port  | default |
+| Port  | Default |
 |-------|---------|
 | Game  | 25565   |

--- a/java/curseforge/egg-curse-forge-generic.json
+++ b/java/curseforge/egg-curse-forge-generic.json
@@ -4,7 +4,7 @@
         "version": "PLCN_v1",
         "update_url": null
     },
-    "exported_at": "2025-05-23T13:10:20+00:00",
+    "exported_at": "2025-05-27T11:05:16-07:00",
     "name": "CurseForge Generic",
     "author": "contact@chromozone.dev",
     "uuid": "019bbf16-a3f3-470a-9c0b-f3995b5e032a",
@@ -40,7 +40,7 @@
     "variables": [
         {
             "name": "Modpack Project ID",
-            "description": "The modpack project ID from the CurseForge site on the pack page, or 'zip' if installing from an uploaded server.zip file.\r\n\r\nFor example, the project Id of https:\/\/www.curseforge.com\/minecraft\/modpacks\/bofa-mods ID is 375152",
+            "description": "The modpack project ID from the CurseForge site on the pack page, or 'zip' if installing from an uploaded server.zip file.\r\n\r\nFor example, the project ID of https:\/\/www.curseforge.com\/minecraft\/modpacks\/bofa-mods is 375152",
             "env_variable": "PROJECT_ID",
             "default_value": "",
             "user_viewable": true,
@@ -49,7 +49,7 @@
                 "required",
                 "string"
             ],
-            "sort": null
+            "sort": 1
         },
         {
             "name": "Modpack File ID",
@@ -61,21 +61,21 @@
             "rules": [
                 "string"
             ],
-            "sort": null
+            "sort": 2
         },
         {
             "name": "CurseForge API Key",
-            "description": "A CurseForge API key is required to use this egg. You can learn how to get an API key here: https:\/\/support.curseforge.com\/en\/support\/solutions\/articles\/9000208346-about-the-curseforge-api-and-how-to-apply-for-a-key",
+            "description": "A CurseForge API key is required to use this egg. This key is not visible to the server owner. You can get an API key here: https:\/\/console.curseforge.com",
             "env_variable": "API_KEY",
             "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
+            "user_viewable": false,
+            "user_editable": false,
             "rules": [
                 "required",
                 "string",
                 "max:60"
             ],
-            "sort": null
+            "sort": 3
         }
     ]
 }

--- a/java/curseforge/egg-pterodactyl-curse-forge-generic.json
+++ b/java/curseforge/egg-pterodactyl-curse-forge-generic.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2025-05-13T18:43:58+00:00",
+    "exported_at": "2025-05-27T11:05:16-07:00",
     "name": "CurseForge Generic",
     "author": "contact@chromozone.dev",
     "description": "A generic egg for a CurseForge modpack.",
@@ -38,7 +38,7 @@
     "variables": [
         {
             "name": "Modpack Project ID",
-            "description": "The modpack project ID from the CurseForge site on the pack page, or 'zip' if installing from an uploaded server.zip file.\r\n\r\nFor example, the project Id of https:\/\/www.curseforge.com\/minecraft\/modpacks\/bofa-mods ID is 375152",
+            "description": "The modpack project ID from the CurseForge site on the pack page, or 'zip' if installing from an uploaded server.zip file.\r\n\r\nFor example, the project ID of https:\/\/www.curseforge.com\/minecraft\/modpacks\/bofa-mods is 375152",
             "env_variable": "PROJECT_ID",
             "default_value": "",
             "user_viewable": true,
@@ -58,11 +58,11 @@
         },
         {
             "name": "CurseForge API Key",
-            "description": "A CurseForge API key is required to use this egg. You can learn how to get an API key here: https:\/\/support.curseforge.com\/en\/support\/solutions\/articles\/9000208346-about-the-curseforge-api-and-how-to-apply-for-a-key",
+            "description": "A CurseForge API key is required to use this egg. This key is not visible to the server owner. You can get an API key here: https:\/\/console.curseforge.com",
             "env_variable": "API_KEY",
             "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
+            "user_viewable": false,
+            "user_editable": false,
             "rules": "required|string|max:60",
             "field_type": "text"
         }


### PR DESCRIPTION
# Description

The current CurseForge support article listed in the README and Egg variable description is misleading and unnecessary. It is much easier to obtain an API key for free in their developer portal at https://console.curseforge.com

- Updated the README and Egg "CurseForge API Key" variable description with this new link.
- Changed the "CurseForge API Key" variable to not be user visible. My reasoning behind this is that the host should maintain one key for all clients instead of requiring clients to obtain their own keys. Also, previously, with it being a required variable, it forced the host to either input their private key or an invalid "Enter your key here" string before the server can be created, which is more clunky in my opinion.
- Added variable `sort` values for the Pelican Egg.
- Small capitalization adjustments.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/pelican-eggs/minecraft/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
* [x] The egg was exported from the panel