### PR TITLE
Remove initial memory allocation from startup command

### DIFF
--- a/java/neoforge/egg-neo-forge.json
+++ b/java/neoforge/egg-neo-forge.json
@@ -22,7 +22,7 @@
         "Java 21": "ghcr.io\/parkervcp\/yolks:java_21"
     },
     "file_denylist": [],
-    "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true @unix_args.txt",
+    "startup": "java -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true @unix_args.txt",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"server-port\": \"{{server.allocations.default.port}}\",\r\n            \"query.port\": \"{{server.allocations.default.port}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \")! For help, type \"\r\n}",


### PR DESCRIPTION
## Summary
Installations of NeoForge were failing with the message:
"Otherwise, the NeoForge installer will not have enough memory."
This failure happened because the egg set an initial Java heap to 128M (`-Xms128M`) in the startup string and that constrained the installer's memory allocation in some environments.

This PR removes the explicit small initial heap value from the startup string so the JVM can allocate according to MaxRAMPercentage and the container/host limits. This allows the NeoForge installer to get the memory it needs during --installServer.

## Changes
- Update egg metadata JSON:
  - `startup` changed from:
    `java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true @unix_args.txt`
    to:
    `java -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true @unix_args.txt`
  - (UUID updated in file metadata — cosmetic / export id change)

No other script logic changed.

## Why
- Setting a very small initial heap (`-Xms128M`) can prevent the JVM from expanding early enough for the installer, resulting in the error referenced in the installer script. Removing the `-Xms` allows the JVM to honor `MaxRAMPercentage` relative to container limits and avoids artificially low initial allocations.

## Verification steps
1. Deploy this egg and run the installation on an environment with at least 1GB memory allocated to the server build.
2. Watch installer output/logs — install should complete and print `Installation process is completed!`.
3. Confirm `libraries/net/neoforged/.../unix_args.txt` is symlinked and server starts with expected args.
4. Test with both `MC_VERSION=latest` and an explicit `NEOFORGE_VERSION` to ensure both code paths work.

## Notes & recommendations
- If the panel/Wings Build Configuration uses `0` (unlimited) memory for the build container, consider setting a concrete memory limit in Wings or the egg build configuration — the install script warns about that.
- Optional further cleanup: the installer error message references `${MINECRAFT_VERSION}` while the script uses `MC_VERSION`. Consider normalising variable names to avoid confusion (not required to fix the reported memory issue).

## Risk
- Low. Change affects only the egg metadata startup string which controls server process JVM args. Installer and script logic are unchanged.

## Rollback
- Revert the startup string to previous value and re-run if regressions found.

