### PR TITLE
Add Java 25 docker image to vanilla egg

### DIFF
--- a/java/vanilla/egg-vanilla-minecraft.yaml
+++ b/java/vanilla/egg-vanilla-minecraft.yaml
@@ -19,6 +19,7 @@ features:
   - java_version
   - pid_limit
 docker_images:
+  'Java 25': 'ghcr.io/pelican-eggs/yolks:java_25'
   'Java 21': 'ghcr.io/pelican-eggs/yolks:java_21'
   'Java 17': 'ghcr.io/pelican-eggs/yolks:java_17'
   'Java 16': 'ghcr.io/pelican-eggs/yolks:java_16'

--- a/java/vanilla/egg-vanilla-minecraft.yaml
+++ b/java/vanilla/egg-vanilla-minecraft.yaml
@@ -2,7 +2,7 @@ _comment: 'DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL'
 meta:
   version: PLCN_v3
   update_url: 'https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/vanilla/egg-vanilla-minecraft.yaml'
-exported_at: '2025-10-31T12:35:33+00:00'
+exported_at: '2026-03-27T18:15:51+00:00'
 name: 'Vanilla Minecraft'
 author: panel@example.com
 uuid: 9ac39f3d-0c34-4d93-8174-c52ab9e6c57b

--- a/java/vanilla/pterodactyl-egg-vanilla-minecraft.json
+++ b/java/vanilla/pterodactyl-egg-vanilla-minecraft.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2025-12-31T13:06:44+00:00",
+    "exported_at": "2026-03-27T18:15:55+00:00",
     "name": "Vanilla Minecraft",
     "author": "panel@example.com",
     "description": "Minecraft is a game about placing blocks and going on adventures. Explore randomly generated worlds\nand build amazing things from the simplest of homes to the grandest of castles. Play in Creative\nMode with unlimited resources or mine deep in Survival Mode, crafting weapons and armor to fend off\ndangerous mobs. Do all this alone or with friends.",
@@ -14,6 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25",
         "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
         "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
         "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",


### PR DESCRIPTION
# Description

To properly support the latest version of Minecraft, version 26.1 (first drop in 2026), which requires at least Java version 25 (class file version 69.0), so that users do not have to set it up themselves.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/pelican-eggs/minecraft/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [ ] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->

## New egg Submissions

1. [ ] Does your submission pass tests (server is connectable)?
2. [ ] Does your egg use a custom docker image?
    * [ ] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?
3. [ ] Have you added the egg to the main README.md and any other README files in subdirectories of the egg (e.g /game_eggs) according to the alphabetical order?
4. [ ] Have you added a unique README.md for the egg you are adding according to the alphabetical order?
5. [ ] You verify that the start command applied does not use a shell script
    * [ ] If some script is needed then it is part of a current yolk or a PR to add one
6. [ ] The egg was exported from the panel