### PR TITLE
Add update URLs and Java 25 to all applicable eggs

### DIFF
--- a/bedrock/LiteLoader-bedrock/egg-liteloader-bedrock-dedicated-server.json
+++ b/bedrock/LiteLoader-bedrock/egg-liteloader-bedrock-dedicated-server.json
@@ -11,7 +11,7 @@
     "description": "LiteLoaderBDS - Epoch-making & Cross-language Bedrock Dedicated Servers Plugin Loader\r\n\r\nLiteLoaderBDS is an unofficial plugin loader that provides basic API support for Bedrock Dedicated Server, with a massive API, lots of packed utility interfaces, a rich event system and powerful basic interface support.",
     "features": null,
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:wine_staging": "ghcr.io\/parkervcp\/yolks:wine_staging"
+        "ghcr.io\/pelican-eggs\/yolks:wine_staging": "ghcr.io\/pelican-eggs\/yolks:wine_staging"
     },
     "file_denylist": [],
     "startup": ".\/lae-ll-launcher bedrock_server_mod.exe",

--- a/bedrock/LiteLoader-bedrock/egg-liteloader-bedrock-dedicated-server.json
+++ b/bedrock/LiteLoader-bedrock/egg-liteloader-bedrock-dedicated-server.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/bedrock/LiteLoader-bedrock/egg-liteloader-bedrock-dedicated-server.json"
     },
     "exported_at": "2024-06-01T19:40:00+00:00",
     "name": "Liteloader Bedrock Dedicated Server",

--- a/bedrock/LiteLoader-bedrock/egg-pterodactyl-liteloader-bedrock-dedicated-server.json
+++ b/bedrock/LiteLoader-bedrock/egg-pterodactyl-liteloader-bedrock-dedicated-server.json
@@ -10,7 +10,7 @@
     "description": "LiteLoaderBDS - Epoch-making \u0026 Cross-language Bedrock Dedicated Servers Plugin Loader\r\n\r\nLiteLoaderBDS is an unofficial plugin loader that provides basic API support for Bedrock Dedicated Server, with a massive API, lots of packed utility interfaces, a rich event system and powerful basic interface support.",
     "features": null,
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:wine_staging": "ghcr.io/parkervcp/yolks:wine_staging"
+        "ghcr.io/pelican-eggs/yolks:wine_staging": "ghcr.io/pelican-eggs/yolks:wine_staging"
     },
     "file_denylist": [],
     "startup": "./lae-ll-launcher bedrock_server_mod.exe",

--- a/bedrock/LiteLoader-bedrock/egg-pterodactyl-liteloader-bedrock-dedicated-server.json
+++ b/bedrock/LiteLoader-bedrock/egg-pterodactyl-liteloader-bedrock-dedicated-server.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/bedrock/LiteLoader-bedrock/egg-pterodactyl-liteloader-bedrock-dedicated-server.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:00+00:00",

--- a/bedrock/PowerNukkitX/egg-power-nukkit-x.json
+++ b/bedrock/PowerNukkitX/egg-power-nukkit-x.json
@@ -11,7 +11,7 @@
     "description": "PowerNukkitX support for Pelican",
     "features": null,
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:debian": "ghcr.io\/parkervcp\/yolks:debian"
+        "ghcr.io\/pelican-eggs\/yolks:debian": "ghcr.io\/pelican-eggs\/yolks:debian"
     },
     "file_denylist": [],
     "startup": ".\/pnx start {{AUTOREBOOT}}",

--- a/bedrock/PowerNukkitX/egg-power-nukkit-x.json
+++ b/bedrock/PowerNukkitX/egg-power-nukkit-x.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/bedrock/PowerNukkitX/egg-power-nukkit-x.json"
     },
     "exported_at": "2024-06-01T19:39:55+00:00",
     "name": "PowerNukkitX",

--- a/bedrock/PowerNukkitX/egg-pterodactyl-power-nukkit-x.json
+++ b/bedrock/PowerNukkitX/egg-pterodactyl-power-nukkit-x.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/bedrock/PowerNukkitX/egg-pterodactyl-power-nukkit-x.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:39:55+00:00",

--- a/bedrock/PowerNukkitX/egg-pterodactyl-power-nukkit-x.json
+++ b/bedrock/PowerNukkitX/egg-pterodactyl-power-nukkit-x.json
@@ -10,7 +10,7 @@
     "description": "PowerNukkitX support for Pterodactyl",
     "features": null,
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:debian": "ghcr.io/parkervcp/yolks:debian"
+        "ghcr.io/pelican-eggs/yolks:debian": "ghcr.io/pelican-eggs/yolks:debian"
     },
     "file_denylist": [],
     "startup": "./pnx start {{AUTOREBOOT}}",

--- a/bedrock/bedrock/egg-pterodactyl-vanilla-bedrock-a-r-m64.json
+++ b/bedrock/bedrock/egg-pterodactyl-vanilla-bedrock-a-r-m64.json
@@ -12,7 +12,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:box64": "ghcr.io\/parkervcp\/yolks:box64"
+        "ghcr.io\/pelican-eggs\/yolks:box64": "ghcr.io\/pelican-eggs\/yolks:box64"
     },
     "file_denylist": [],
     "startup": "box64 .\/bedrock_server",

--- a/bedrock/bedrock/egg-pterodactyl-vanilla-bedrock-a-r-m64.json
+++ b/bedrock/bedrock/egg-pterodactyl-vanilla-bedrock-a-r-m64.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/bedrock/bedrock/egg-pterodactyl-vanilla-bedrock-a-r-m64.json"
     },
     "exported_at": "2025-06-18T12:40:19+02:00",
     "name": "Vanilla Bedrock ARM64",

--- a/bedrock/bedrock/egg-pterodactyl-vanilla-bedrock.json
+++ b/bedrock/bedrock/egg-pterodactyl-vanilla-bedrock.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/bedrock/bedrock/egg-pterodactyl-vanilla-bedrock.json"
     },
     "exported_at": "2025-06-18T12:40:19+02:00",
     "name": "Vanilla Bedrock",

--- a/bedrock/bedrock/egg-pterodactyl-vanilla-bedrock.json
+++ b/bedrock/bedrock/egg-pterodactyl-vanilla-bedrock.json
@@ -12,7 +12,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:debian": "ghcr.io\/parkervcp\/yolks:debian"
+        "ghcr.io\/pelican-eggs\/yolks:debian": "ghcr.io\/pelican-eggs\/yolks:debian"
     },
     "file_denylist": [],
     "startup": ".\/bedrock_server",

--- a/bedrock/bedrock/egg-vanilla-bedrock-a-r-m64.json
+++ b/bedrock/bedrock/egg-vanilla-bedrock-a-r-m64.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/bedrock/bedrock/egg-vanilla-bedrock-a-r-m64.json"
     },
     "exported_at": "2025-06-18T12:40:19+02:00",
     "name": "Vanilla Bedrock ARM64",

--- a/bedrock/bedrock/egg-vanilla-bedrock-a-r-m64.json
+++ b/bedrock/bedrock/egg-vanilla-bedrock-a-r-m64.json
@@ -13,7 +13,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:box64": "ghcr.io\/parkervcp\/yolks:box64"
+        "ghcr.io\/pelican-eggs\/yolks:box64": "ghcr.io\/pelican-eggs\/yolks:box64"
     },
     "file_denylist": [],
     "startup": "box64 .\/bedrock_server",

--- a/bedrock/bedrock/egg-vanilla-bedrock.json
+++ b/bedrock/bedrock/egg-vanilla-bedrock.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PLCN_v1",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/bedrock/bedrock/egg-vanilla-bedrock.json"
     },
     "exported_at": "2025-06-18T12:40:19+02:00",
     "name": "Vanilla Bedrock",

--- a/bedrock/bedrock/egg-vanilla-bedrock.json
+++ b/bedrock/bedrock/egg-vanilla-bedrock.json
@@ -14,7 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:debian": "ghcr.io\/parkervcp\/yolks:debian"
+        "ghcr.io\/pelican-eggs\/yolks:debian": "ghcr.io\/pelican-eggs\/yolks:debian"
     },
     "file_denylist": [],
     "startup": ".\/bedrock_server",

--- a/bedrock/gomint/egg-go-mint.json
+++ b/bedrock/gomint/egg-go-mint.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/bedrock/gomint/egg-go-mint.json"
     },
     "exported_at": "2024-06-01T19:39:46+00:00",
     "name": "GoMint",

--- a/bedrock/gomint/egg-go-mint.json
+++ b/bedrock/gomint/egg-go-mint.json
@@ -15,10 +15,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "ghcr.io\/parkervcp\/yolks:java_11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "ghcr.io\/parkervcp\/yolks:java_16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "ghcr.io\/parkervcp\/yolks:java_17": "ghcr.io\/parkervcp\/yolks:java_17"
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "ghcr.io\/pelican-eggs\/yolks:java_11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "ghcr.io\/pelican-eggs\/yolks:java_16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "ghcr.io\/pelican-eggs\/yolks:java_17": "ghcr.io\/pelican-eggs\/yolks:java_17"
     },
     "file_denylist": [],
     "startup": "java --add-opens java.base\/java.nio=io.netty.common --add-exports java.base\/jdk.internal.misc=io.netty.common -p modules -m gomint.server\/io.gomint.server.Bootstrap",

--- a/bedrock/gomint/egg-pterodactyl-go-mint.json
+++ b/bedrock/gomint/egg-pterodactyl-go-mint.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/bedrock/gomint/egg-pterodactyl-go-mint.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:39:46+00:00",

--- a/bedrock/gomint/egg-pterodactyl-go-mint.json
+++ b/bedrock/gomint/egg-pterodactyl-go-mint.json
@@ -14,10 +14,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_11": "ghcr.io/parkervcp/yolks:java_11",
-        "ghcr.io/parkervcp/yolks:java_16": "ghcr.io/parkervcp/yolks:java_16",
-        "ghcr.io/parkervcp/yolks:java_17": "ghcr.io/parkervcp/yolks:java_17",
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "ghcr.io/pelican-eggs/yolks:java_16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "ghcr.io/pelican-eggs/yolks:java_17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java --add-opens java.base/java.nio=io.netty.common --add-exports java.base/jdk.internal.misc=io.netty.common -p modules -m gomint.server/io.gomint.server.Bootstrap",

--- a/bedrock/nukkit/egg-nukkit.json
+++ b/bedrock/nukkit/egg-nukkit.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/bedrock/nukkit/egg-nukkit.json"
     },
     "exported_at": "2024-06-01T19:39:55+00:00",
     "name": "Nukkit",

--- a/bedrock/nukkit/egg-nukkit.json
+++ b/bedrock/nukkit/egg-nukkit.json
@@ -11,10 +11,10 @@
     "description": "Nukkit is a Nuclear-Powered Server Software For Minecraft: Pocket Edition\r\n\r\nhttps:\/\/cloudburstmc.org",
     "features": null,
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "ghcr.io\/parkervcp\/yolks:java_16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "ghcr.io\/parkervcp\/yolks:java_17": "ghcr.io\/parkervcp\/yolks:java_17"
+        "ghcr.io\/pelican-eggs\/yolks:java_11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "ghcr.io\/pelican-eggs\/yolks:java_16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "ghcr.io\/pelican-eggs\/yolks:java_17": "ghcr.io\/pelican-eggs\/yolks:java_17"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/bedrock/nukkit/egg-pterodactyl-nukkit.json
+++ b/bedrock/nukkit/egg-pterodactyl-nukkit.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/bedrock/nukkit/egg-pterodactyl-nukkit.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:39:55+00:00",

--- a/bedrock/nukkit/egg-pterodactyl-nukkit.json
+++ b/bedrock/nukkit/egg-pterodactyl-nukkit.json
@@ -10,10 +10,10 @@
     "description": "Nukkit is a Nuclear-Powered Server Software For Minecraft: Pocket Edition\r\n\r\nhttps://cloudburstmc.org",
     "features": null,
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_11": "ghcr.io/parkervcp/yolks:java_11",
-        "ghcr.io/parkervcp/yolks:java_16": "ghcr.io/parkervcp/yolks:java_16",
-        "ghcr.io/parkervcp/yolks:java_17": "ghcr.io/parkervcp/yolks:java_17",
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "ghcr.io/pelican-eggs/yolks:java_16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "ghcr.io/pelican-eggs/yolks:java_17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/bedrock/pocketmine_mp/egg-pocketmine-m-p.json
+++ b/bedrock/pocketmine_mp/egg-pocketmine-m-p.json
@@ -13,7 +13,7 @@
     "tags": [],
     "features": [],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:debian": "ghcr.io/parkervcp/yolks:debian"
+        "ghcr.io/pelican-eggs/yolks:debian": "ghcr.io/pelican-eggs/yolks:debian"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/bedrock/pocketmine_mp/egg-pterodactyl-pocketmine-m-p.json
+++ b/bedrock/pocketmine_mp/egg-pterodactyl-pocketmine-m-p.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/bedrock/pocketmine_mp/egg-pterodactyl-pocketmine-m-p.json"
     },
     "exported_at": "2025-12-06T14:24:50+00:00",
     "name": "PocketmineMP",

--- a/bedrock/pocketmine_mp/egg-pterodactyl-pocketmine-m-p.json
+++ b/bedrock/pocketmine_mp/egg-pterodactyl-pocketmine-m-p.json
@@ -10,7 +10,7 @@
     "description": "Pocketmine Egg\r\nby onekintaro from swisscrafting.ch\r\nwith the nice help from #eggs Channel on Pelican Discord :)",
     "features": null,
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:debian": "ghcr.io\/parkervcp\/yolks:debian"
+        "ghcr.io\/pelican-eggs\/yolks:debian": "ghcr.io\/pelican-eggs\/yolks:debian"
     },
     "file_denylist": [],
     "startup": ".\/bin\/php7\/bin\/php .\/PocketMine-MP.phar --no-wizard",

--- a/crossplay/purpur-geysermc-floodgate/egg-pterodactyl-purpur--geyser--floodgate.json
+++ b/crossplay/purpur-geysermc-floodgate/egg-pterodactyl-purpur--geyser--floodgate.json
@@ -14,12 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true --add-modules=jdk.incubator.vector -jar {{SERVER_JARFILE}}",

--- a/crossplay/purpur-geysermc-floodgate/egg-pterodactyl-purpur--geyser--floodgate.json
+++ b/crossplay/purpur-geysermc-floodgate/egg-pterodactyl-purpur--geyser--floodgate.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/crossplay/purpur-geysermc-floodgate/egg-pterodactyl-purpur--geyser--floodgate.json"
     },
     "exported_at": "2024-09-17T22:59:20+02:00",
     "name": "Purpur-Geyser-Floodgate",
@@ -18,7 +18,8 @@
         "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
         "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
         "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21"
+        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true --add-modules=jdk.incubator.vector -jar {{SERVER_JARFILE}}",

--- a/crossplay/purpur-geysermc-floodgate/egg-purpur--geyser--floodgate.json
+++ b/crossplay/purpur-geysermc-floodgate/egg-purpur--geyser--floodgate.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/crossplay/purpur-geysermc-floodgate/egg-purpur--geyser--floodgate.json"
     },
     "exported_at": "2024-08-02T12:03:34+00:00",
     "name": "Purpur-Geyser-Floodgate",
@@ -19,7 +19,8 @@
         "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
         "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
         "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21"
+        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true --add-modules=jdk.incubator.vector -jar {{SERVER_JARFILE}}",

--- a/crossplay/purpur-geysermc-floodgate/egg-purpur--geyser--floodgate.json
+++ b/crossplay/purpur-geysermc-floodgate/egg-purpur--geyser--floodgate.json
@@ -15,12 +15,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true --add-modules=jdk.incubator.vector -jar {{SERVER_JARFILE}}",

--- a/java/cuberite/egg-cuberite.json
+++ b/java/cuberite/egg-cuberite.json
@@ -15,7 +15,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:debian": "ghcr.io\/parkervcp\/yolks:debian"
+        "ghcr.io\/pelican-eggs\/yolks:debian": "ghcr.io\/pelican-eggs\/yolks:debian"
     },
     "file_denylist": [],
     "startup": ".\/Cuberite",

--- a/java/cuberite/egg-cuberite.json
+++ b/java/cuberite/egg-cuberite.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/cuberite/egg-cuberite.json"
     },
     "exported_at": "2024-06-01T19:39:48+00:00",
     "name": "Cuberite",

--- a/java/cuberite/egg-pterodactyl-cuberite.json
+++ b/java/cuberite/egg-pterodactyl-cuberite.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/cuberite/egg-pterodactyl-cuberite.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:39:48+00:00",

--- a/java/cuberite/egg-pterodactyl-cuberite.json
+++ b/java/cuberite/egg-pterodactyl-cuberite.json
@@ -14,7 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:debian": "ghcr.io/parkervcp/yolks:debian"
+        "ghcr.io/pelican-eggs/yolks:debian": "ghcr.io/pelican-eggs/yolks:debian"
     },
     "file_denylist": [],
     "startup": "./Cuberite",

--- a/java/curseforge/egg-curse-forge-generic.json
+++ b/java/curseforge/egg-curse-forge-generic.json
@@ -16,12 +16,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java $([[ -f user_jvm_args.txt ]] && printf %s \"@user_jvm_args.txt\") -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true $([[ ! -f unix_args.txt ]] && printf %s \"-jar `cat .serverjar`\" || printf %s \"@unix_args.txt\")",

--- a/java/curseforge/egg-curse-forge-generic.json
+++ b/java/curseforge/egg-curse-forge-generic.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PLCN_v1",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/curseforge/egg-curse-forge-generic.json"
     },
     "exported_at": "2025-05-27T11:05:16-07:00",
     "name": "CurseForge Generic",
@@ -16,11 +16,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
+        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
         "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
+        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
+        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java $([[ -f user_jvm_args.txt ]] && printf %s \"@user_jvm_args.txt\") -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true $([[ ! -f unix_args.txt ]] && printf %s \"-jar `cat .serverjar`\" || printf %s \"@unix_args.txt\")",

--- a/java/curseforge/egg-pterodactyl-curse-forge-generic.json
+++ b/java/curseforge/egg-pterodactyl-curse-forge-generic.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/curseforge/egg-pterodactyl-curse-forge-generic.json"
     },
     "exported_at": "2025-05-27T11:05:16-07:00",
     "name": "CurseForge Generic",
@@ -14,11 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
+        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
         "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
+        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
+        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java $([[ -f user_jvm_args.txt ]] && printf %s \"@user_jvm_args.txt\") -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true $([[ ! -f unix_args.txt ]] && printf %s \"-jar `cat .serverjar`\" || printf %s \"@unix_args.txt\")",

--- a/java/curseforge/egg-pterodactyl-curse-forge-generic.json
+++ b/java/curseforge/egg-pterodactyl-curse-forge-generic.json
@@ -14,12 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java $([[ -f user_jvm_args.txt ]] && printf %s \"@user_jvm_args.txt\") -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true $([[ ! -f unix_args.txt ]] && printf %s \"-jar `cat .serverjar`\" || printf %s \"@unix_args.txt\")",

--- a/java/fabric/egg-fabric.json
+++ b/java/fabric/egg-fabric.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PLCN_v3",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/fabric/egg-fabric.json"
     },
     "exported_at": "2025-12-19T20:55:03+00:00",
     "name": "Fabric",
@@ -21,7 +21,8 @@
         "Java 11": "ghcr.io/parkervcp/yolks:java_11",
         "Java 16": "ghcr.io/parkervcp/yolks:java_16",
         "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21"
+        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
+        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/java/fabric/egg-fabric.json
+++ b/java/fabric/egg-fabric.json
@@ -17,12 +17,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
-        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8",
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 21": "ghcr.io/pelican-eggs/yolks:java_21",
+        "Java 25": "ghcr.io/pelican-eggs/yolks:java_25"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/java/fabric/egg-pterodactyl-fabric.json
+++ b/java/fabric/egg-pterodactyl-fabric.json
@@ -14,12 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/fabric/egg-pterodactyl-fabric.json
+++ b/java/fabric/egg-pterodactyl-fabric.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/fabric/egg-pterodactyl-fabric.json"
     },
     "exported_at": "2024-11-13T15:26:34+00:00",
     "name": "Fabric",
@@ -14,12 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
-        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
-        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
-        "Java 21": "ghcr.io\/pterodactyl\/yolks:java_21",
-        "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8"
+        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
+        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
+        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
+        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
+        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/feather/egg-feather.json
+++ b/java/feather/egg-feather.json
@@ -11,7 +11,7 @@
     "description": "An experimental Minecraft server implementation written in Rust.",
     "features": null,
     "docker_images": [
-        "ghcr.io\/parkervcp\/yolks:debian"
+        "ghcr.io\/pelican-eggs\/yolks:debian"
     ],
     "file_denylist": [],
     "startup": ".\/feather-server",

--- a/java/feather/egg-feather.json
+++ b/java/feather/egg-feather.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/feather/egg-feather.json"
     },
     "exported_at": "2024-06-01T19:40:20+00:00",
     "name": "Feather",

--- a/java/folia/egg-folia.json
+++ b/java/folia/egg-folia.json
@@ -15,10 +15,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 18": "ghcr.io\/parkervcp\/yolks:java_18",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 18": "ghcr.io\/pelican-eggs\/yolks:java_18",
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/folia/egg-folia.json
+++ b/java/folia/egg-folia.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/folia/egg-folia.json"
     },
     "exported_at": "2024-06-01T19:39:42+00:00",
     "name": "Folia",
@@ -15,9 +15,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 21": "ghcr.io\/pterodactyl\/yolks:java_21",
-        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
+        "Java 18": "ghcr.io\/parkervcp\/yolks:java_18",
+        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/folia/egg-pterodactyl-folia.json
+++ b/java/folia/egg-pterodactyl-folia.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/folia/egg-pterodactyl-folia.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:39:42+00:00",
@@ -14,9 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 17": "ghcr.io/pterodactyl/yolks:java_17",
-        "Java 18": "ghcr.io/pterodactyl/yolks:java_18",
-        "Java 21": "ghcr.io/pterodactyl/yolks:java_21"
+        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
+        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
+        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
+        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
+        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
+        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/folia/egg-pterodactyl-folia.json
+++ b/java/folia/egg-pterodactyl-folia.json
@@ -14,12 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
-        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8",
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 21": "ghcr.io/pelican-eggs/yolks:java_21",
+        "Java 25": "ghcr.io/pelican-eggs/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/forge/egg-forge-minecraft.yaml
+++ b/java/forge/egg-forge-minecraft.yaml
@@ -17,6 +17,7 @@ features:
   - java_version
   - pid_limit
 docker_images:
+  'Java 25': 'ghcr.io/pelican-eggs/yolks:java_25'
   'Java 21': 'ghcr.io/pelican-eggs/yolks:java_21'
   'Java 17': 'ghcr.io/pelican-eggs/yolks:java_17'
   'Java 16': 'ghcr.io/pelican-eggs/yolks:java_16'
@@ -149,7 +150,7 @@ scripts:
       "
       java -jar installer.jar --installServer || { echo -e "
       Install failed using Forge version ${FORGE_VERSION} and Minecraft version ${MINECRAFT_VERSION}.
-      Should you be using unlimited memory value of 0, make sure to increase the default install resource limits in the Daemon config or specify exact allocated memory in the server Build Configuration instead of 0! 
+      Should you be using unlimited memory value of 0, make sure to increase the default install resource limits in the Daemon config or specify exact allocated memory in the server Build Configuration instead of 0!
       Otherwise, the Forge installer will not have enough memory."; exit 4; }
 
       # Check if we need a symlink for 1.17+ Forge JPMS args

--- a/java/forge/pterodactyl-egg-forge-minecraft.json
+++ b/java/forge/pterodactyl-egg-forge-minecraft.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/forge/pterodactyl-egg-forge-minecraft.json"
     },
     "exported_at": "2025-12-31T13:05:02+00:00",
     "name": "Forge Minecraft",

--- a/java/ftb/egg-f-t-b-server.json
+++ b/java/ftb/egg-f-t-b-server.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PLCN_v3",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/ftb/egg-f-t-b-server.json"
     },
     "exported_at": "2025-12-19T20:55:40+00:00",
     "name": "FTB Server",
@@ -17,12 +17,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
-        "Java 19": "ghcr.io/parkervcp/yolks:java_19",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
+        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
         "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8"
+        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
+        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
+        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
+        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/java/ftb/egg-f-t-b-server.json
+++ b/java/ftb/egg-f-t-b-server.json
@@ -17,12 +17,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
-        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8",
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 21": "ghcr.io/pelican-eggs/yolks:java_21",
+        "Java 25": "ghcr.io/pelican-eggs/yolks:java_25"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/java/ftb/egg-pterodactyl-f-t-b-server.json
+++ b/java/ftb/egg-pterodactyl-f-t-b-server.json
@@ -14,13 +14,13 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25",
-        "Java 19": "ghcr.io\/parkervcp\/yolks:java_19",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25",
+        "Java 19": "ghcr.io\/pelican-eggs\/yolks:java_19",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true $( [[  ! -f unix_args.txt ]] && printf %s \"-jar start-server.jar\" || printf %s \"@unix_args.txt\" )",

--- a/java/ftb/egg-pterodactyl-f-t-b-server.json
+++ b/java/ftb/egg-pterodactyl-f-t-b-server.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/ftb/egg-pterodactyl-f-t-b-server.json"
     },
     "exported_at": "2025-02-18T18:11:44+00:00",
     "name": "FTB Server",
@@ -15,6 +15,7 @@
     ],
     "docker_images": {
         "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25",
         "Java 19": "ghcr.io\/parkervcp\/yolks:java_19",
         "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
         "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",

--- a/java/ftb/outdated/egg-f-t-b-modpacks-ch-server.json
+++ b/java/ftb/outdated/egg-f-t-b-modpacks-ch-server.json
@@ -15,11 +15,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 18": "ghcr.io\/parkervcp\/yolks:java_18"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 18": "ghcr.io\/pelican-eggs\/yolks:java_18"
     },
     "file_denylist": [],
     "startup": "java -javaagent:log4jfix\/Log4jPatcher-1.0.0.jar -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true $( [[  ! -f unix_args.txt ]] && printf %s \"-jar start-server.jar\" || printf %s \"@unix_args.txt\" )",

--- a/java/ftb/outdated/egg-f-t-b-modpacks-ch-server.json
+++ b/java/ftb/outdated/egg-f-t-b-modpacks-ch-server.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/ftb/outdated/egg-f-t-b-modpacks-ch-server.json"
     },
     "exported_at": "2024-06-01T19:39:44+00:00",
     "name": "FTB-modpacks.ch Server",
@@ -15,11 +15,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8",
-        "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
-        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
-        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
+        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
+        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
+        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
+        "Java 18": "ghcr.io\/parkervcp\/yolks:java_18"
     },
     "file_denylist": [],
     "startup": "java -javaagent:log4jfix\/Log4jPatcher-1.0.0.jar -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true $( [[  ! -f unix_args.txt ]] && printf %s \"-jar start-server.jar\" || printf %s \"@unix_args.txt\" )",

--- a/java/ftb/outdated/egg-f-t-b-revelation.json
+++ b/java/ftb/outdated/egg-f-t-b-revelation.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/ftb/outdated/egg-f-t-b-revelation.json"
     },
     "exported_at": "2024-06-01T19:39:44+00:00",
     "name": "FTB Revelation",

--- a/java/ftb/outdated/egg-f-t-b-revelation.json
+++ b/java/ftb/outdated/egg-f-t-b-revelation.json
@@ -15,7 +15,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar FTBserver-*.jar",

--- a/java/ftb/outdated/egg-feed-the-beast.json
+++ b/java/ftb/outdated/egg-feed-the-beast.json
@@ -15,7 +15,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar FTBserv*.jar",

--- a/java/ftb/outdated/egg-feed-the-beast.json
+++ b/java/ftb/outdated/egg-feed-the-beast.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/ftb/outdated/egg-feed-the-beast.json"
     },
     "exported_at": "2024-06-01T19:39:42+00:00",
     "name": "Feed the Beast",

--- a/java/ftb/outdated/egg-pterodactyl-f-t-b-modpacks-ch-server.json
+++ b/java/ftb/outdated/egg-pterodactyl-f-t-b-modpacks-ch-server.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/ftb/outdated/egg-pterodactyl-f-t-b-modpacks-ch-server.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:39:44+00:00",
@@ -14,11 +14,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 11": "ghcr.io/pterodactyl/yolks:java_11",
-        "Java 16": "ghcr.io/pterodactyl/yolks:java_16",
-        "Java 17": "ghcr.io/pterodactyl/yolks:java_17",
-        "Java 18": "ghcr.io/pterodactyl/yolks:java_18",
-        "Java 8": "ghcr.io/pterodactyl/yolks:java_8"
+        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
+        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
+        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
+        "Java 18": "ghcr.io/parkervcp/yolks:java_18",
+        "Java 8": "ghcr.io/parkervcp/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -javaagent:log4jfix/Log4jPatcher-1.0.0.jar -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true $( [[  ! -f unix_args.txt ]] \u0026\u0026 printf %s \"-jar start-server.jar\" || printf %s \"@unix_args.txt\" )",

--- a/java/ftb/outdated/egg-pterodactyl-f-t-b-modpacks-ch-server.json
+++ b/java/ftb/outdated/egg-pterodactyl-f-t-b-modpacks-ch-server.json
@@ -14,11 +14,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 18": "ghcr.io/parkervcp/yolks:java_18",
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8"
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 18": "ghcr.io/pelican-eggs/yolks:java_18",
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -javaagent:log4jfix/Log4jPatcher-1.0.0.jar -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true $( [[  ! -f unix_args.txt ]] \u0026\u0026 printf %s \"-jar start-server.jar\" || printf %s \"@unix_args.txt\" )",

--- a/java/ftb/outdated/egg-pterodactyl-f-t-b-revelation.json
+++ b/java/ftb/outdated/egg-pterodactyl-f-t-b-revelation.json
@@ -14,7 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar FTBserver-*.jar",

--- a/java/ftb/outdated/egg-pterodactyl-f-t-b-revelation.json
+++ b/java/ftb/outdated/egg-pterodactyl-f-t-b-revelation.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/ftb/outdated/egg-pterodactyl-f-t-b-revelation.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:39:44+00:00",

--- a/java/ftb/outdated/egg-pterodactyl-feed-the-beast.json
+++ b/java/ftb/outdated/egg-pterodactyl-feed-the-beast.json
@@ -14,7 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar FTBserv*.jar",

--- a/java/ftb/outdated/egg-pterodactyl-feed-the-beast.json
+++ b/java/ftb/outdated/egg-pterodactyl-feed-the-beast.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/ftb/outdated/egg-pterodactyl-feed-the-beast.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:39:42+00:00",

--- a/java/glowstone/egg-glowstone.json
+++ b/java/glowstone/egg-glowstone.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PLCN_v3",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/glowstone/egg-glowstone.json"
     },
     "exported_at": "2025-12-19T20:56:01+00:00",
     "name": "Glowstone",
@@ -13,11 +13,11 @@
     "tags": [],
     "features": null,
     "docker_images": {
-        "Java 8": "ghcr.io/pterodactyl/yolks:java_8",
-        "Java 11": "ghcr.io/pterodactyl/yolks:java_11",
-        "Java 16": "ghcr.io/pterodactyl/yolks:java_16",
-        "Java 17": "ghcr.io/pterodactyl/yolks:java_17",
-        "Java 18": "ghcr.io/pterodactyl/yolks:java_18"
+        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
+        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
+        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
+        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
+        "Java 18": "ghcr.io/parkervcp/yolks:java_18"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/java/glowstone/egg-glowstone.json
+++ b/java/glowstone/egg-glowstone.json
@@ -13,11 +13,11 @@
     "tags": [],
     "features": null,
     "docker_images": {
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 18": "ghcr.io/parkervcp/yolks:java_18"
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8",
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 18": "ghcr.io/pelican-eggs/yolks:java_18"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/java/glowstone/egg-pterodactyl-glowstone.json
+++ b/java/glowstone/egg-pterodactyl-glowstone.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/glowstone/egg-pterodactyl-glowstone.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:39:45+00:00",
@@ -10,11 +10,11 @@
     "description": "Glowstone is an open-source server implementation for Minecraft: Java Edition 1.12.2 and up.",
     "features": null,
     "docker_images": {
-        "Java 11": "ghcr.io/pterodactyl/yolks:java_11",
-        "Java 16": "ghcr.io/pterodactyl/yolks:java_16",
-        "Java 17": "ghcr.io/pterodactyl/yolks:java_17",
-        "Java 18": "ghcr.io/pterodactyl/yolks:java_18",
-        "Java 8": "ghcr.io/pterodactyl/yolks:java_8"
+        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
+        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
+        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
+        "Java 18": "ghcr.io/parkervcp/yolks:java_18",
+        "Java 8": "ghcr.io/parkervcp/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms768M -Xmx{{SERVER_MEMORY}}M -XX:+UseG1GC -jar {{SERVER_JARFILE}}",

--- a/java/glowstone/egg-pterodactyl-glowstone.json
+++ b/java/glowstone/egg-pterodactyl-glowstone.json
@@ -10,11 +10,11 @@
     "description": "Glowstone is an open-source server implementation for Minecraft: Java Edition 1.12.2 and up.",
     "features": null,
     "docker_images": {
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 18": "ghcr.io/parkervcp/yolks:java_18",
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8"
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 18": "ghcr.io/pelican-eggs/yolks:java_18",
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms768M -Xmx{{SERVER_MEMORY}}M -XX:+UseG1GC -jar {{SERVER_JARFILE}}",

--- a/java/ketting/egg-ketting.json
+++ b/java/ketting/egg-ketting.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PLCN_v1",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/ketting/egg-ketting.json"
     },
     "exported_at": "2025-01-10T15:28:19+00:00",
     "name": "Ketting",
@@ -16,7 +16,8 @@
     ],
     "docker_images": {
         "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21"
+        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JAR_FILE}} -minecraftVersion {{GAME_VERSION}}",

--- a/java/ketting/egg-ketting.json
+++ b/java/ketting/egg-ketting.json
@@ -15,9 +15,9 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JAR_FILE}} -minecraftVersion {{GAME_VERSION}}",

--- a/java/ketting/egg-pterodactyl-ketting.json
+++ b/java/ketting/egg-pterodactyl-ketting.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/ketting/egg-pterodactyl-ketting.json"
     },
     "exported_at": "2025-01-10T16:29:06+01:00",
     "name": "Ketting",
@@ -11,7 +11,8 @@
     "features": null,
     "docker_images": {
         "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21"
+        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JAR_FILE}} -minecraftVersion {{GAME_VERSION}}",

--- a/java/ketting/egg-pterodactyl-ketting.json
+++ b/java/ketting/egg-pterodactyl-ketting.json
@@ -10,9 +10,9 @@
     "description": "Magma successor for 1.20- with plugins and mods.",
     "features": null,
     "docker_images": {
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JAR_FILE}} -minecraftVersion {{GAME_VERSION}}",

--- a/java/krypton/egg-krypton.json
+++ b/java/krypton/egg-krypton.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/krypton/egg-krypton.json"
     },
     "exported_at": "2024-06-01T19:39:47+00:00",
     "name": "Krypton",
@@ -15,11 +15,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8",
-        "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
-        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
-        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
+        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
+        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
+        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
+        "Java 18": "ghcr.io\/parkervcp\/yolks:java_18"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JAR}}",

--- a/java/krypton/egg-krypton.json
+++ b/java/krypton/egg-krypton.json
@@ -15,11 +15,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 18": "ghcr.io\/parkervcp\/yolks:java_18"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 18": "ghcr.io\/pelican-eggs\/yolks:java_18"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JAR}}",

--- a/java/krypton/egg-pterodactyl-krypton.json
+++ b/java/krypton/egg-pterodactyl-krypton.json
@@ -14,11 +14,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 18": "ghcr.io/parkervcp/yolks:java_18",
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8"
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 18": "ghcr.io/pelican-eggs/yolks:java_18",
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JAR}}",

--- a/java/krypton/egg-pterodactyl-krypton.json
+++ b/java/krypton/egg-pterodactyl-krypton.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/krypton/egg-pterodactyl-krypton.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:39:47+00:00",
@@ -14,11 +14,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 11": "ghcr.io/pterodactyl/yolks:java_11",
-        "Java 16": "ghcr.io/pterodactyl/yolks:java_16",
-        "Java 17": "ghcr.io/pterodactyl/yolks:java_17",
-        "Java 18": "ghcr.io/pterodactyl/yolks:java_18",
-        "Java 8": "ghcr.io/pterodactyl/yolks:java_8"
+        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
+        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
+        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
+        "Java 18": "ghcr.io/parkervcp/yolks:java_18",
+        "Java 8": "ghcr.io/parkervcp/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JAR}}",

--- a/java/limbo/egg-limbo.json
+++ b/java/limbo/egg-limbo.json
@@ -11,7 +11,7 @@
     "description": "Standalone server program Limbo.",
     "features": null,
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_17": "ghcr.io\/parkervcp\/yolks:java_17"
+        "ghcr.io\/pelican-eggs\/yolks:java_17": "ghcr.io\/pelican-eggs\/yolks:java_17"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}",

--- a/java/limbo/egg-limbo.json
+++ b/java/limbo/egg-limbo.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/limbo/egg-limbo.json"
     },
     "exported_at": "2024-06-01T19:40:00+00:00",
     "name": "Limbo",
@@ -11,7 +11,7 @@
     "description": "Standalone server program Limbo.",
     "features": null,
     "docker_images": {
-        "ghcr.io\/pterodactyl\/yolks:java_17": "ghcr.io\/pterodactyl\/yolks:java_17"
+        "ghcr.io\/parkervcp\/yolks:java_17": "ghcr.io\/parkervcp\/yolks:java_17"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}",

--- a/java/limbo/egg-pterodactyl-limbo.json
+++ b/java/limbo/egg-pterodactyl-limbo.json
@@ -10,7 +10,7 @@
     "description": "Standalone server program Limbo.",
     "features": null,
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_17": "ghcr.io/parkervcp/yolks:java_17"
+        "ghcr.io/pelican-eggs/yolks:java_17": "ghcr.io/pelican-eggs/yolks:java_17"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}",

--- a/java/limbo/egg-pterodactyl-limbo.json
+++ b/java/limbo/egg-pterodactyl-limbo.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/limbo/egg-pterodactyl-limbo.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:00+00:00",
@@ -10,7 +10,7 @@
     "description": "Standalone server program Limbo.",
     "features": null,
     "docker_images": {
-        "ghcr.io/pterodactyl/yolks:java_17": "ghcr.io/pterodactyl/yolks:java_17"
+        "ghcr.io/parkervcp/yolks:java_17": "ghcr.io/parkervcp/yolks:java_17"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}",

--- a/java/magma/egg-magma.json
+++ b/java/magma/egg-magma.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/magma/egg-magma.json"
     },
     "exported_at": "2024-06-01T19:40:01+00:00",
     "name": "Magma",
@@ -15,11 +15,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8",
-        "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
-        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
-        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
+        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
+        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
+        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
+        "Java 18": "ghcr.io\/parkervcp\/yolks:java_18"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}",

--- a/java/magma/egg-magma.json
+++ b/java/magma/egg-magma.json
@@ -15,11 +15,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 18": "ghcr.io\/parkervcp\/yolks:java_18"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 18": "ghcr.io\/pelican-eggs\/yolks:java_18"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}",

--- a/java/magma/egg-pterodactyl-magma.json
+++ b/java/magma/egg-pterodactyl-magma.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/magma/egg-pterodactyl-magma.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:01+00:00",
@@ -14,11 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 11": "ghcr.io/pterodactyl/yolks:java_11",
-        "Java 16": "ghcr.io/pterodactyl/yolks:java_16",
-        "Java 17": "ghcr.io/pterodactyl/yolks:java_17",
-        "Java 18": "ghcr.io/pterodactyl/yolks:java_18",
-        "Java 8": "ghcr.io/pterodactyl/yolks:java_8"
+        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
+        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
+        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
+        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
+        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
+        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}",

--- a/java/magma/egg-pterodactyl-magma.json
+++ b/java/magma/egg-pterodactyl-magma.json
@@ -14,12 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
-        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8",
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 21": "ghcr.io/pelican-eggs/yolks:java_21",
+        "Java 25": "ghcr.io/pelican-eggs/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}",

--- a/java/modrinth/egg-modrinth-generic.json
+++ b/java/modrinth/egg-modrinth-generic.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PLCN_v3",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/modrinth/egg-modrinth-generic.json"
     },
     "exported_at": "2025-12-19T20:53:27+00:00",
     "name": "Modrinth Generic",
@@ -22,7 +22,7 @@
         "Java 16": "ghcr.io/parkervcp/yolks:java_16",
         "Java 17": "ghcr.io/parkervcp/yolks:java_17",
         "Java 21": "ghcr.io/parkervcp/yolks:java_21",
-        "Java 22": "ghcr.io/parkervcp/yolks:java_22"
+        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/java/modrinth/egg-modrinth-generic.json
+++ b/java/modrinth/egg-modrinth-generic.json
@@ -17,12 +17,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
-        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8",
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 21": "ghcr.io/pelican-eggs/yolks:java_21",
+        "Java 25": "ghcr.io/pelican-eggs/yolks:java_25"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/java/modrinth/egg-pterodactyl-modrinth-generic.json
+++ b/java/modrinth/egg-pterodactyl-modrinth-generic.json
@@ -15,12 +15,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java $([[ -f user_jvm_args.txt ]] \u0026\u0026 printf %s \"@user_jvm_args.txt\") -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true $([[ ! -f unix_args.txt ]] \u0026\u0026 printf %s \"-jar `cat .serverjar`\" || printf %s \"@unix_args.txt\")",

--- a/java/modrinth/egg-pterodactyl-modrinth-generic.json
+++ b/java/modrinth/egg-pterodactyl-modrinth-generic.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY pterodactyl.io",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/modrinth/egg-pterodactyl-modrinth-generic.json"
 
     },
     "exported_at": "2025-01-13T09:44:32+00:00",
@@ -19,7 +19,8 @@
         "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
         "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
         "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21"
+        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java $([[ -f user_jvm_args.txt ]] \u0026\u0026 printf %s \"@user_jvm_args.txt\") -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true $([[ ! -f unix_args.txt ]] \u0026\u0026 printf %s \"-jar `cat .serverjar`\" || printf %s \"@unix_args.txt\")",

--- a/java/mohist/egg-mohist.json
+++ b/java/mohist/egg-mohist.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PLCN_v1",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/mohist/egg-mohist.json"
     },
     "exported_at": "2024-11-02T08:50:15+00:00",
     "name": "MohistMC",
@@ -19,7 +19,8 @@
         "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
         "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
         "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "java 21": "ghcr.io\/parkervcp\/yolks:java_21"
+        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/mohist/egg-mohist.json
+++ b/java/mohist/egg-mohist.json
@@ -15,12 +15,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/mohist/egg-pterodactyl-mohist.json
+++ b/java/mohist/egg-pterodactyl-mohist.json
@@ -14,12 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/mohist/egg-pterodactyl-mohist.json
+++ b/java/mohist/egg-pterodactyl-mohist.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/mohist/egg-pterodactyl-mohist.json"
     },
     "exported_at": "2024-11-02T09:48:29+01:00",
     "name": "MohistMC",
@@ -18,7 +18,8 @@
         "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
         "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
         "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "java 21": "ghcr.io\/parkervcp\/yolks:java_21"
+        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/nanolimbo/egg-nano-limbo.json
+++ b/java/nanolimbo/egg-nano-limbo.json
@@ -15,7 +15,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/nanolimbo/egg-nano-limbo.json
+++ b/java/nanolimbo/egg-nano-limbo.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/nanolimbo/egg-nano-limbo.json"
     },
     "exported_at": "2024-06-01T19:40:02+00:00",
     "name": "NanoLimbo",

--- a/java/nanolimbo/egg-pterodactyl-nano-limbo.json
+++ b/java/nanolimbo/egg-pterodactyl-nano-limbo.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/nanolimbo/egg-pterodactyl-nano-limbo.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:02+00:00",

--- a/java/nanolimbo/egg-pterodactyl-nano-limbo.json
+++ b/java/nanolimbo/egg-pterodactyl-nano-limbo.json
@@ -14,7 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/neoforge/egg-neo-forge.json
+++ b/java/neoforge/egg-neo-forge.json
@@ -17,11 +17,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
         "Java 8": "ghcr.io/parkervcp/yolks:java_8",
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21"
+        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
+        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
+        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
+        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
+        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/java/neoforge/egg-neo-forge.json
+++ b/java/neoforge/egg-neo-forge.json
@@ -17,12 +17,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
-        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8",
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 21": "ghcr.io/pelican-eggs/yolks:java_21",
+        "Java 25": "ghcr.io/pelican-eggs/yolks:java_25"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/java/neoforge/egg-pterodactyl-neo-forge.json
+++ b/java/neoforge/egg-pterodactyl-neo-forge.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/neoforge/egg-pterodactyl-neo-forge.json"
     },
     "exported_at": "2024-11-13T15:30:48+01:00",
     "name": "NeoForge",
@@ -14,11 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
+        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
         "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
         "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
         "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
         "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true @unix_args.txt",

--- a/java/neoforge/egg-pterodactyl-neo-forge.json
+++ b/java/neoforge/egg-pterodactyl-neo-forge.json
@@ -14,12 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true @unix_args.txt",

--- a/java/paper/egg-paper.yaml
+++ b/java/paper/egg-paper.yaml
@@ -15,6 +15,7 @@ features:
   - java_version
   - pid_limit
 docker_images:
+  'Java 25': 'ghcr.io/pelican-eggs/yolks:java_25'
   'Java 21': 'ghcr.io/pelican-eggs/yolks:java_21'
   'Java 17': 'ghcr.io/pelican-eggs/yolks:java_17'
   'Java 16': 'ghcr.io/pelican-eggs/yolks:java_16'

--- a/java/paper/pterodactyl-egg-paper.json
+++ b/java/paper/pterodactyl-egg-paper.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/paper/pterodactyl-egg-paper.json"
     },
     "exported_at": "2025-12-31T13:01:49+00:00",
     "name": "Paper",

--- a/java/purpur/egg-pterodactyl-purpur.json
+++ b/java/purpur/egg-pterodactyl-purpur.json
@@ -14,12 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java --add-modules=jdk.incubator.vector -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/purpur/egg-pterodactyl-purpur.json
+++ b/java/purpur/egg-pterodactyl-purpur.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/purpur/egg-pterodactyl-purpur.json"
     },
     "exported_at": "2024-11-20T10:52:34+01:00",
     "name": "Purpur",
@@ -14,11 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
+        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
         "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
         "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
         "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
         "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java --add-modules=jdk.incubator.vector -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/purpur/egg-purpur.json
+++ b/java/purpur/egg-purpur.json
@@ -15,12 +15,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java --add-modules=jdk.incubator.vector -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/purpur/egg-purpur.json
+++ b/java/purpur/egg-purpur.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PLCN_v1",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/purpur/egg-purpur.json"
     },
     "exported_at": "2024-11-20T09:50:13+00:00",
     "name": "Purpur",
@@ -19,7 +19,8 @@
         "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
         "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
         "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21"
+        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java --add-modules=jdk.incubator.vector -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/java/quilt/egg-pterodactyl-quilt.json
+++ b/java/quilt/egg-pterodactyl-quilt.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/quilt/egg-pterodactyl-quilt.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:39:59+00:00",
@@ -10,11 +10,12 @@
     "description": "The Quilt project is an open-source, community-driven modding toolchain designed primarily for Minecraft. By focusing on speed, ease of use and modularity, Quilt aims to provide a sleek and modern modding toolchain with an open ecosystem.",
     "features": null,
     "docker_images": {
-        "Java 11": "ghcr.io/pterodactyl/yolks:java_11",
-        "Java 16": "ghcr.io/pterodactyl/yolks:java_16",
-        "Java 17": "ghcr.io/pterodactyl/yolks:java_17",
-        "Java 18": "ghcr.io/pterodactyl/yolks:java_18",
-        "Java 8": "ghcr.io/pterodactyl/yolks:java_8"
+        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
+        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
+        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
+        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
+        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
+        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}} nogui",

--- a/java/quilt/egg-pterodactyl-quilt.json
+++ b/java/quilt/egg-pterodactyl-quilt.json
@@ -10,12 +10,12 @@
     "description": "The Quilt project is an open-source, community-driven modding toolchain designed primarily for Minecraft. By focusing on speed, ease of use and modularity, Quilt aims to provide a sleek and modern modding toolchain with an open ecosystem.",
     "features": null,
     "docker_images": {
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
-        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8",
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 21": "ghcr.io/pelican-eggs/yolks:java_21",
+        "Java 25": "ghcr.io/pelican-eggs/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}} nogui",

--- a/java/quilt/egg-quilt.json
+++ b/java/quilt/egg-quilt.json
@@ -13,12 +13,12 @@
     "tags": [],
     "features": null,
     "docker_images": {
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
-        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8",
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 21": "ghcr.io/pelican-eggs/yolks:java_21",
+        "Java 25": "ghcr.io/pelican-eggs/yolks:java_25"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/java/quilt/egg-quilt.json
+++ b/java/quilt/egg-quilt.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PLCN_v3",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/quilt/egg-quilt.json"
     },
     "exported_at": "2025-12-19T20:56:18+00:00",
     "name": "Quilt",
@@ -13,11 +13,12 @@
     "tags": [],
     "features": null,
     "docker_images": {
-        "Java 17": "ghcr.io/pterodactyl/yolks:java_17",
-        "Java 8": "ghcr.io/pterodactyl/yolks:java_8",
-        "Java 11": "ghcr.io/pterodactyl/yolks:java_11",
-        "Java 16": "ghcr.io/pterodactyl/yolks:java_16",
-        "Java 18": "ghcr.io/pterodactyl/yolks:java_18"
+        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
+        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
+        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
+        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
+        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
+        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/java/spigot/egg-pterodactyl-spigot.json
+++ b/java/spigot/egg-pterodactyl-spigot.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/spigot/egg-pterodactyl-spigot.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:39:58+00:00",
@@ -14,11 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
+        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
         "Java 11": "ghcr.io/parkervcp/yolks:java_11",
         "Java 16": "ghcr.io/parkervcp/yolks:java_16",
         "Java 17": "ghcr.io/parkervcp/yolks:java_17",
         "Java 21": "ghcr.io/parkervcp/yolks:java_21",
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8"
+        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/spigot/egg-pterodactyl-spigot.json
+++ b/java/spigot/egg-pterodactyl-spigot.json
@@ -14,12 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
-        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8",
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 21": "ghcr.io/pelican-eggs/yolks:java_21",
+        "Java 25": "ghcr.io/pelican-eggs/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/spigot/egg-spigot.json
+++ b/java/spigot/egg-spigot.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/spigot/egg-spigot.json"
     },
     "exported_at": "2024-06-01T19:39:58+00:00",
     "name": "Spigot",
@@ -19,7 +19,8 @@
         "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
         "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
         "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21"
+        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/spigot/egg-spigot.json
+++ b/java/spigot/egg-spigot.json
@@ -15,12 +15,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/spongeforge/egg-pterodactyl-sponge-forge.json
+++ b/java/spongeforge/egg-pterodactyl-sponge-forge.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/spongeforge/egg-pterodactyl-sponge-forge.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:12+00:00",
@@ -14,11 +14,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 11": "ghcr.io/pterodactyl/yolks:java_11",
-        "Java 16": "ghcr.io/pterodactyl/yolks:java_16",
-        "Java 17": "ghcr.io/pterodactyl/yolks:java_17",
-        "Java 18": "ghcr.io/pterodactyl/yolks:java_18",
-        "Java 8": "ghcr.io/pterodactyl/yolks:java_8"
+        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
+        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
+        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
+        "Java 18": "ghcr.io/parkervcp/yolks:java_18",
+        "Java 8": "ghcr.io/parkervcp/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/spongeforge/egg-pterodactyl-sponge-forge.json
+++ b/java/spongeforge/egg-pterodactyl-sponge-forge.json
@@ -14,11 +14,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 18": "ghcr.io/parkervcp/yolks:java_18",
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8"
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 18": "ghcr.io/pelican-eggs/yolks:java_18",
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/spongeforge/egg-sponge-forge.json
+++ b/java/spongeforge/egg-sponge-forge.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/spongeforge/egg-sponge-forge.json"
     },
     "exported_at": "2024-06-01T19:40:12+00:00",
     "name": "SpongeForge",
@@ -15,11 +15,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8",
-        "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
-        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
-        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
+        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
+        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
+        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
+        "Java 18": "ghcr.io\/parkervcp\/yolks:java_18"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/spongeforge/egg-sponge-forge.json
+++ b/java/spongeforge/egg-sponge-forge.json
@@ -15,11 +15,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 18": "ghcr.io\/parkervcp\/yolks:java_18"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 18": "ghcr.io\/pelican-eggs\/yolks:java_18"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/spongevanilla/egg-pterodactyl-sponge-vanilla.json
+++ b/java/spongevanilla/egg-pterodactyl-sponge-vanilla.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/spongevanilla/egg-pterodactyl-sponge-vanilla.json"
     },
     "exported_at": "2025-12-31T12:59:35+00:00",
     "name": "Sponge",

--- a/java/spongevanilla/egg-sponge.yaml
+++ b/java/spongevanilla/egg-sponge.yaml
@@ -15,6 +15,7 @@ features:
   - java_version
   - pid_limit
 docker_images:
+  'Java 25': 'ghcr.io/pelican-eggs/yolks:java_25'
   'Java 21': 'ghcr.io/pelican-eggs/yolks:java_21'
   'Java 17': 'ghcr.io/pelican-eggs/yolks:java_17'
   'Java 16': 'ghcr.io/pelican-eggs/yolks:java_16'
@@ -53,7 +54,7 @@ scripts:
         fi
         echo -e "Found latest version for ${SPONGE_TYPE}"
       else
-        if [ $SPONGE_TYPE = 'spongevanilla' ]; then 
+        if [ $SPONGE_TYPE = 'spongevanilla' ]; then
           VERSIONS_JSON=$(curl -sSL https://dl-api.spongepowered.org/v2/groups/org.spongepowered/artifacts/${SPONGE_TYPE}/versions?tags=,minecraft:${MINECRAFT_VERSION}&offset=0&limit=1)
         else
           FORGETAG='forge'
@@ -62,15 +63,15 @@ scripts:
           fi
           VERSIONS_JSON=$(curl -sSL https://dl-api.spongepowered.org/v2/groups/org.spongepowered/artifacts/${SPONGE_TYPE}/versions?tags=,minecraft:${MINECRAFT_VERSION},${FORGETAG}:${FORGE_VERSION}&offset=0&limit=1)
         fi
-        
+
         if [ -z "${VERSIONS_JSON}" ]; then
           echo -e "Failed to find recommended ${MINECRAFT_VERSION} version for ${SPONGE_TYPE} ${FORGE_VERSION}!"
           exit 1
         fi
-        
+
         VERSION_KEY=$(echo $VERSIONS_JSON | jq -r '.artifacts | to_entries[0].key')
         TARGET_VERSION_JSON=$(curl -sSL https://dl-api.spongepowered.org/v2/groups/org.spongepowered/artifacts/${SPONGE_TYPE}/versions/${VERSION_KEY})
-        
+
         if [ -z "${TARGET_VERSION_JSON}" ]; then
           echo -e "Failed to find ${VERSION_KEY} for ${SPONGE_TYPE} ${FORGE_VERSION}!"
           exit 1

--- a/java/technic/Tekkit-2/egg-pterodactyl-tekkit2.json
+++ b/java/technic/Tekkit-2/egg-pterodactyl-tekkit2.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/Tekkit-2/egg-pterodactyl-tekkit2.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:17+00:00",
@@ -13,8 +13,8 @@
         "java_version"
     ],
     "docker_images": {
-        "Java11": "ghcr.io/pterodactyl/yolks:java_11",
-        "Java8": "ghcr.io/pterodactyl/yolks:java_8"
+        "Java11": "ghcr.io/parkervcp/yolks:java_11",
+        "Java8": "ghcr.io/parkervcp/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -server  -Xms128M -Xmx{{SERVER_MEMORY}}M -Dfml.queryResult=confirm -jar forge.jar nogui",

--- a/java/technic/Tekkit-2/egg-pterodactyl-tekkit2.json
+++ b/java/technic/Tekkit-2/egg-pterodactyl-tekkit2.json
@@ -13,8 +13,8 @@
         "java_version"
     ],
     "docker_images": {
-        "Java11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java8": "ghcr.io/parkervcp/yolks:java_8"
+        "Java11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -server  -Xms128M -Xmx{{SERVER_MEMORY}}M -Dfml.queryResult=confirm -jar forge.jar nogui",

--- a/java/technic/Tekkit-2/egg-tekkit2.json
+++ b/java/technic/Tekkit-2/egg-tekkit2.json
@@ -14,8 +14,8 @@
         "java_version"
     ],
     "docker_images": {
-        "Java8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java11": "ghcr.io\/parkervcp\/yolks:java_11"
+        "Java8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java11": "ghcr.io\/pelican-eggs\/yolks:java_11"
     },
     "file_denylist": [],
     "startup": "java -server  -Xms128M -Xmx{{SERVER_MEMORY}}M -Dfml.queryResult=confirm -jar forge.jar nogui",

--- a/java/technic/Tekkit-2/egg-tekkit2.json
+++ b/java/technic/Tekkit-2/egg-tekkit2.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/Tekkit-2/egg-tekkit2.json"
     },
     "exported_at": "2024-06-01T19:40:17+00:00",
     "name": "Tekkit 2",
@@ -14,8 +14,8 @@
         "java_version"
     ],
     "docker_images": {
-        "Java8": "ghcr.io\/pterodactyl\/yolks:java_8",
-        "Java11": "ghcr.io\/pterodactyl\/yolks:java_11"
+        "Java8": "ghcr.io\/parkervcp\/yolks:java_8",
+        "Java11": "ghcr.io\/parkervcp\/yolks:java_11"
     },
     "file_denylist": [],
     "startup": "java -server  -Xms128M -Xmx{{SERVER_MEMORY}}M -Dfml.queryResult=confirm -jar forge.jar nogui",

--- a/java/technic/Tekkit/egg-pterodactyl-tekkit.json
+++ b/java/technic/Tekkit/egg-pterodactyl-tekkit.json
@@ -14,10 +14,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_11": "ghcr.io/parkervcp/yolks:java_11",
-        "ghcr.io/parkervcp/yolks:java_16": "ghcr.io/parkervcp/yolks:java_16",
-        "ghcr.io/parkervcp/yolks:java_17": "ghcr.io/parkervcp/yolks:java_17",
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "ghcr.io/pelican-eggs/yolks:java_16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "ghcr.io/pelican-eggs/yolks:java_17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar Tekkit.jar",

--- a/java/technic/Tekkit/egg-pterodactyl-tekkit.json
+++ b/java/technic/Tekkit/egg-pterodactyl-tekkit.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/Tekkit/egg-pterodactyl-tekkit.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:13+00:00",

--- a/java/technic/Tekkit/egg-tekkit.json
+++ b/java/technic/Tekkit/egg-tekkit.json
@@ -15,10 +15,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "ghcr.io\/parkervcp\/yolks:java_11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "ghcr.io\/parkervcp\/yolks:java_16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "ghcr.io\/parkervcp\/yolks:java_17": "ghcr.io\/parkervcp\/yolks:java_17"
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "ghcr.io\/pelican-eggs\/yolks:java_11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "ghcr.io\/pelican-eggs\/yolks:java_16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "ghcr.io\/pelican-eggs\/yolks:java_17": "ghcr.io\/pelican-eggs\/yolks:java_17"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar Tekkit.jar",

--- a/java/technic/Tekkit/egg-tekkit.json
+++ b/java/technic/Tekkit/egg-tekkit.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/Tekkit/egg-tekkit.json"
     },
     "exported_at": "2024-06-01T19:40:13+00:00",
     "name": "Tekkit",

--- a/java/technic/attack-of-the-bteam/egg-attack-of-the-b--team.json
+++ b/java/technic/attack-of-the-bteam/egg-attack-of-the-b--team.json
@@ -15,7 +15,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar BTeam.jar",

--- a/java/technic/attack-of-the-bteam/egg-attack-of-the-b--team.json
+++ b/java/technic/attack-of-the-bteam/egg-attack-of-the-b--team.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/attack-of-the-bteam/egg-attack-of-the-b--team.json"
     },
     "exported_at": "2024-06-01T19:39:48+00:00",
     "name": "Attack of the B-Team",

--- a/java/technic/attack-of-the-bteam/egg-pterodactyl-attack-of-the-b--team.json
+++ b/java/technic/attack-of-the-bteam/egg-pterodactyl-attack-of-the-b--team.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/attack-of-the-bteam/egg-pterodactyl-attack-of-the-b--team.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:39:48+00:00",

--- a/java/technic/attack-of-the-bteam/egg-pterodactyl-attack-of-the-b--team.json
+++ b/java/technic/attack-of-the-bteam/egg-pterodactyl-attack-of-the-b--team.json
@@ -14,7 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar BTeam.jar",

--- a/java/technic/blightfall/egg-blightfall.json
+++ b/java/technic/blightfall/egg-blightfall.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/blightfall/egg-blightfall.json"
     },
     "exported_at": "2024-06-01T19:39:49+00:00",
     "name": "Blightfall",

--- a/java/technic/blightfall/egg-blightfall.json
+++ b/java/technic/blightfall/egg-blightfall.json
@@ -15,7 +15,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar Blightfall.jar",

--- a/java/technic/blightfall/egg-pterodactyl-blightfall.json
+++ b/java/technic/blightfall/egg-pterodactyl-blightfall.json
@@ -14,7 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar Blightfall.jar",

--- a/java/technic/blightfall/egg-pterodactyl-blightfall.json
+++ b/java/technic/blightfall/egg-pterodactyl-blightfall.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/blightfall/egg-pterodactyl-blightfall.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:39:49+00:00",

--- a/java/technic/hexxit/egg-hexxit.json
+++ b/java/technic/hexxit/egg-hexxit.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/hexxit/egg-hexxit.json"
     },
     "exported_at": "2024-06-01T19:39:46+00:00",
     "name": "Hexxit",

--- a/java/technic/hexxit/egg-hexxit.json
+++ b/java/technic/hexxit/egg-hexxit.json
@@ -15,7 +15,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar Hexxit.jar",

--- a/java/technic/hexxit/egg-pterodactyl-hexxit.json
+++ b/java/technic/hexxit/egg-pterodactyl-hexxit.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/hexxit/egg-pterodactyl-hexxit.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:39:46+00:00",

--- a/java/technic/hexxit/egg-pterodactyl-hexxit.json
+++ b/java/technic/hexxit/egg-pterodactyl-hexxit.json
@@ -14,7 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar Hexxit.jar",

--- a/java/technic/tekkit-classic/egg-pterodactyl-tekkit-classic.json
+++ b/java/technic/tekkit-classic/egg-pterodactyl-tekkit-classic.json
@@ -14,10 +14,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_11": "ghcr.io/parkervcp/yolks:java_11",
-        "ghcr.io/parkervcp/yolks:java_16": "ghcr.io/parkervcp/yolks:java_16",
-        "ghcr.io/parkervcp/yolks:java_17": "ghcr.io/parkervcp/yolks:java_17",
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "ghcr.io/pelican-eggs/yolks:java_16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "ghcr.io/pelican-eggs/yolks:java_17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar Tekkit.jar",

--- a/java/technic/tekkit-classic/egg-pterodactyl-tekkit-classic.json
+++ b/java/technic/tekkit-classic/egg-pterodactyl-tekkit-classic.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/tekkit-classic/egg-pterodactyl-tekkit-classic.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:16+00:00",

--- a/java/technic/tekkit-classic/egg-tekkit-classic.json
+++ b/java/technic/tekkit-classic/egg-tekkit-classic.json
@@ -15,10 +15,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "ghcr.io\/parkervcp\/yolks:java_11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "ghcr.io\/parkervcp\/yolks:java_16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "ghcr.io\/parkervcp\/yolks:java_17": "ghcr.io\/parkervcp\/yolks:java_17"
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "ghcr.io\/pelican-eggs\/yolks:java_11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "ghcr.io\/pelican-eggs\/yolks:java_16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "ghcr.io\/pelican-eggs\/yolks:java_17": "ghcr.io\/pelican-eggs\/yolks:java_17"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar Tekkit.jar",

--- a/java/technic/tekkit-classic/egg-tekkit-classic.json
+++ b/java/technic/tekkit-classic/egg-tekkit-classic.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/tekkit-classic/egg-tekkit-classic.json"
     },
     "exported_at": "2024-06-01T19:40:16+00:00",
     "name": "Tekkit Classic",

--- a/java/technic/tekkit-legends/egg-pterodactyl-tekkit-legends.json
+++ b/java/technic/tekkit-legends/egg-pterodactyl-tekkit-legends.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/tekkit-legends/egg-pterodactyl-tekkit-legends.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:18+00:00",

--- a/java/technic/tekkit-legends/egg-pterodactyl-tekkit-legends.json
+++ b/java/technic/tekkit-legends/egg-pterodactyl-tekkit-legends.json
@@ -14,7 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar TekkitLegends.jar",

--- a/java/technic/tekkit-legends/egg-tekkit-legends.json
+++ b/java/technic/tekkit-legends/egg-tekkit-legends.json
@@ -15,7 +15,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar TekkitLegends.jar",

--- a/java/technic/tekkit-legends/egg-tekkit-legends.json
+++ b/java/technic/tekkit-legends/egg-tekkit-legends.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/tekkit-legends/egg-tekkit-legends.json"
     },
     "exported_at": "2024-06-01T19:40:18+00:00",
     "name": "Tekkit Legends",

--- a/java/technic/tekkit-smp/egg-pterodactyl-tekkit-smp.json
+++ b/java/technic/tekkit-smp/egg-pterodactyl-tekkit-smp.json
@@ -14,8 +14,8 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11"
     },
     "file_denylist": [],
     "startup": "java -server -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -Dfml.queryResult=confirm -jar forge.jar nogui",

--- a/java/technic/tekkit-smp/egg-pterodactyl-tekkit-smp.json
+++ b/java/technic/tekkit-smp/egg-pterodactyl-tekkit-smp.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/tekkit-smp/egg-pterodactyl-tekkit-smp.json"
     },
     "exported_at": "2024-09-12T21:48:20+02:00",
     "name": "Tekkit SMP",

--- a/java/technic/tekkit-smp/egg-tekkit-smp.json
+++ b/java/technic/tekkit-smp/egg-tekkit-smp.json
@@ -15,8 +15,8 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java11": "ghcr.io\/parkervcp\/yolks:java_11"
+        "Java8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java11": "ghcr.io\/pelican-eggs\/yolks:java_11"
     },
     "file_denylist": [],
     "startup": "java -server -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -Dfml.queryResult=confirm -jar forge.jar nogui",

--- a/java/technic/the-1-12-2-pack/egg-pterodactyl-the1-12-2-pack.json
+++ b/java/technic/the-1-12-2-pack/egg-pterodactyl-the1-12-2-pack.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/the-1-12-2-pack/egg-pterodactyl-the1-12-2-pack.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:19+00:00",

--- a/java/technic/the-1-12-2-pack/egg-pterodactyl-the1-12-2-pack.json
+++ b/java/technic/the-1-12-2-pack/egg-pterodactyl-the1-12-2-pack.json
@@ -14,7 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar forge-*.jar",

--- a/java/technic/the-1-12-2-pack/egg-the1-12-2-pack.json
+++ b/java/technic/the-1-12-2-pack/egg-the1-12-2-pack.json
@@ -15,7 +15,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar forge-*.jar",

--- a/java/technic/the-1-12-2-pack/egg-the1-12-2-pack.json
+++ b/java/technic/the-1-12-2-pack/egg-the1-12-2-pack.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/the-1-12-2-pack/egg-the1-12-2-pack.json"
     },
     "exported_at": "2024-06-01T19:40:19+00:00",
     "name": "The 1.12.2 Pack",

--- a/java/technic/the-1-7-10-pack/egg-pterodactyl-the1-7-10-pack.json
+++ b/java/technic/the-1-7-10-pack/egg-pterodactyl-the1-7-10-pack.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/the-1-7-10-pack/egg-pterodactyl-the1-7-10-pack.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:17+00:00",

--- a/java/technic/the-1-7-10-pack/egg-pterodactyl-the1-7-10-pack.json
+++ b/java/technic/the-1-7-10-pack/egg-pterodactyl-the1-7-10-pack.json
@@ -14,7 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar forge-*.jar",

--- a/java/technic/the-1-7-10-pack/egg-the1-7-10-pack.json
+++ b/java/technic/the-1-7-10-pack/egg-the1-7-10-pack.json
@@ -15,7 +15,7 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar forge-*.jar",

--- a/java/technic/the-1-7-10-pack/egg-the1-7-10-pack.json
+++ b/java/technic/the-1-7-10-pack/egg-the1-7-10-pack.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/technic/the-1-7-10-pack/egg-the1-7-10-pack.json"
     },
     "exported_at": "2024-06-01T19:40:17+00:00",
     "name": "The 1.7.10 Pack",

--- a/java/vanilla/pterodactyl-egg-vanilla-minecraft.json
+++ b/java/vanilla/pterodactyl-egg-vanilla-minecraft.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/vanilla/pterodactyl-egg-vanilla-minecraft.json"
     },
     "exported_at": "2026-03-27T18:15:55+00:00",
     "name": "Vanilla Minecraft",

--- a/java/vanillacord/egg-pterodactyl-vanilla-cord.json
+++ b/java/vanillacord/egg-pterodactyl-vanilla-cord.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/vanillacord/egg-pterodactyl-vanilla-cord.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:08+00:00",
@@ -14,11 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 11": "ghcr.io/pterodactyl/yolks:java_11",
-        "Java 16": "ghcr.io/pterodactyl/yolks:java_16",
-        "Java 17": "ghcr.io/pterodactyl/yolks:java_17",
-        "Java 18": "ghcr.io/pterodactyl/yolks:java_18",
-        "Java 8": "ghcr.io/pterodactyl/yolks:java_8"
+        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
+        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
+        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
+        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
+        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
+        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/vanillacord/egg-pterodactyl-vanilla-cord.json
+++ b/java/vanillacord/egg-pterodactyl-vanilla-cord.json
@@ -14,12 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
-        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8",
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 21": "ghcr.io/pelican-eggs/yolks:java_21",
+        "Java 25": "ghcr.io/pelican-eggs/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/vanillacord/egg-vanilla-cord.json
+++ b/java/vanillacord/egg-vanilla-cord.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/java/vanillacord/egg-vanilla-cord.json"
     },
     "exported_at": "2024-06-01T19:40:08+00:00",
     "name": "VanillaCord",
@@ -15,11 +15,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8",
-        "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
-        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
-        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
+        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
+        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
+        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
+        "Java 18": "ghcr.io\/parkervcp\/yolks:java_18"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/java/vanillacord/egg-vanilla-cord.json
+++ b/java/vanillacord/egg-vanilla-cord.json
@@ -15,11 +15,11 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io\/parkervcp\/yolks:java_8",
-        "Java 11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "Java 16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "Java 17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "Java 18": "ghcr.io\/parkervcp\/yolks:java_18"
+        "Java 8": "ghcr.io\/pelican-eggs\/yolks:java_8",
+        "Java 11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "Java 16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "Java 17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "Java 18": "ghcr.io\/pelican-eggs\/yolks:java_18"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/proxy/bedrock/waterdog_pe/egg-pterodactyl-waterdog-p-e.json
+++ b/proxy/bedrock/waterdog_pe/egg-pterodactyl-waterdog-p-e.json
@@ -14,10 +14,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_11": "ghcr.io/parkervcp/yolks:java_11",
-        "ghcr.io/parkervcp/yolks:java_16": "ghcr.io/parkervcp/yolks:java_16",
-        "ghcr.io/parkervcp/yolks:java_17": "ghcr.io/parkervcp/yolks:java_17",
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "ghcr.io/pelican-eggs/yolks:java_16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "ghcr.io/pelican-eggs/yolks:java_17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Dterminal.ansi=true -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/proxy/bedrock/waterdog_pe/egg-pterodactyl-waterdog-p-e.json
+++ b/proxy/bedrock/waterdog_pe/egg-pterodactyl-waterdog-p-e.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/bedrock/waterdog_pe/egg-pterodactyl-waterdog-p-e.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:10+00:00",

--- a/proxy/bedrock/waterdog_pe/egg-waterdog-p-e.json
+++ b/proxy/bedrock/waterdog_pe/egg-waterdog-p-e.json
@@ -15,10 +15,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "ghcr.io\/parkervcp\/yolks:java_16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "ghcr.io\/parkervcp\/yolks:java_11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/pelican-eggs\/yolks:java_17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "ghcr.io\/pelican-eggs\/yolks:java_16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "ghcr.io\/pelican-eggs\/yolks:java_11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Dterminal.ansi=true -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/proxy/bedrock/waterdog_pe/egg-waterdog-p-e.json
+++ b/proxy/bedrock/waterdog_pe/egg-waterdog-p-e.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/bedrock/waterdog_pe/egg-waterdog-p-e.json"
     },
     "exported_at": "2024-06-01T19:40:10+00:00",
     "name": "Waterdog PE",

--- a/proxy/cross_platform/waterdog/egg-pterodactyl-waterdog.json
+++ b/proxy/cross_platform/waterdog/egg-pterodactyl-waterdog.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/cross_platform/waterdog/egg-pterodactyl-waterdog.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:10+00:00",

--- a/proxy/cross_platform/waterdog/egg-pterodactyl-waterdog.json
+++ b/proxy/cross_platform/waterdog/egg-pterodactyl-waterdog.json
@@ -14,10 +14,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_11": "ghcr.io/parkervcp/yolks:java_11",
-        "ghcr.io/parkervcp/yolks:java_16": "ghcr.io/parkervcp/yolks:java_16",
-        "ghcr.io/parkervcp/yolks:java_17": "ghcr.io/parkervcp/yolks:java_17",
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "ghcr.io/pelican-eggs/yolks:java_16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "ghcr.io/pelican-eggs/yolks:java_17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/proxy/cross_platform/waterdog/egg-waterdog.json
+++ b/proxy/cross_platform/waterdog/egg-waterdog.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/cross_platform/waterdog/egg-waterdog.json"
     },
     "exported_at": "2024-06-01T19:40:10+00:00",
     "name": "Waterdog",

--- a/proxy/cross_platform/waterdog/egg-waterdog.json
+++ b/proxy/cross_platform/waterdog/egg-waterdog.json
@@ -15,10 +15,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "ghcr.io\/parkervcp\/yolks:java_16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "ghcr.io\/parkervcp\/yolks:java_11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/pelican-eggs\/yolks:java_17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "ghcr.io\/pelican-eggs\/yolks:java_16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "ghcr.io\/pelican-eggs\/yolks:java_11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",

--- a/proxy/java/alwaysauth/egg-always-auth.json
+++ b/proxy/java/alwaysauth/egg-always-auth.json
@@ -14,7 +14,7 @@
     ],
     "features": [],
     "docker_images": {
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21"
+        "Java 21": "ghcr.io/pelican-eggs/yolks:java_21"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/proxy/java/alwaysauth/egg-pterodactyl-always-auth.json
+++ b/proxy/java/alwaysauth/egg-pterodactyl-always-auth.json
@@ -10,7 +10,7 @@
     "description": "A simple proxy that sits between your server and Mojang's auth services that ensures even when they're offline, you stay online!",
     "features": null,
     "docker_images": {
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21"
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{JARFILE}}",

--- a/proxy/java/alwaysauth/egg-pterodactyl-always-auth.json
+++ b/proxy/java/alwaysauth/egg-pterodactyl-always-auth.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/java/alwaysauth/egg-pterodactyl-always-auth.json"
     },
     "exported_at": "2025-12-24T22:04:11+00:00",
     "name": "Always Auth",

--- a/proxy/java/bungeecord/egg-bungeecord.yaml
+++ b/proxy/java/bungeecord/egg-bungeecord.yaml
@@ -21,6 +21,7 @@ features:
   - java_version
   - pid_limit
 docker_images:
+  'Java 25': 'ghcr.io/pelican-eggs/yolks:java_25'
   'Java 21': 'ghcr.io/pelican-eggs/yolks:java_21'
   'Java 17': 'ghcr.io/pelican-eggs/yolks:java_17'
   'Java 16': 'ghcr.io/pelican-eggs/yolks:java_16'

--- a/proxy/java/bungeecord/pterodactyl-egg-bungeecord.json
+++ b/proxy/java/bungeecord/pterodactyl-egg-bungeecord.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/java/bungeecord/pterodactyl-egg-bungeecord.json"
     },
     "exported_at": "2025-12-31T12:56:47+00:00",
     "name": "Bungeecord",

--- a/proxy/java/travertine/egg-pterodactyl-travertine.json
+++ b/proxy/java/travertine/egg-pterodactyl-travertine.json
@@ -14,10 +14,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_11": "ghcr.io/parkervcp/yolks:java_11",
-        "ghcr.io/parkervcp/yolks:java_16": "ghcr.io/parkervcp/yolks:java_16",
-        "ghcr.io/parkervcp/yolks:java_17": "ghcr.io/parkervcp/yolks:java_17",
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "ghcr.io/pelican-eggs/yolks:java_16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "ghcr.io/pelican-eggs/yolks:java_17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/proxy/java/travertine/egg-pterodactyl-travertine.json
+++ b/proxy/java/travertine/egg-pterodactyl-travertine.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/java/travertine/egg-pterodactyl-travertine.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:19+00:00",

--- a/proxy/java/travertine/egg-travertine.json
+++ b/proxy/java/travertine/egg-travertine.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/java/travertine/egg-travertine.json"
     },
     "exported_at": "2024-06-01T19:40:19+00:00",
     "name": "Travertine",

--- a/proxy/java/travertine/egg-travertine.json
+++ b/proxy/java/travertine/egg-travertine.json
@@ -15,10 +15,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "ghcr.io\/parkervcp\/yolks:java_16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "ghcr.io\/parkervcp\/yolks:java_11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/pelican-eggs\/yolks:java_17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "ghcr.io\/pelican-eggs\/yolks:java_16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "ghcr.io\/pelican-eggs\/yolks:java_11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/proxy/java/velocity/egg-pterodactyl-velocity.json
+++ b/proxy/java/velocity/egg-pterodactyl-velocity.json
@@ -14,12 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
-        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8",
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 21": "ghcr.io/pelican-eggs/yolks:java_21",
+        "Java 25": "ghcr.io/pelican-eggs/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:+UnlockExperimentalVMOptions -XX:+ParallelRefProcEnabled -XX:+AlwaysPreTouch -XX:MaxInlineLevel=15 -jar {{SERVER_JARFILE}}",

--- a/proxy/java/velocity/egg-pterodactyl-velocity.json
+++ b/proxy/java/velocity/egg-pterodactyl-velocity.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/java/velocity/egg-pterodactyl-velocity.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:07+00:00",
@@ -14,11 +14,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 11": "ghcr.io/pterodactyl/yolks:java_11",
-        "Java 16": "ghcr.io/pterodactyl/yolks:java_16",
-        "Java 17": "ghcr.io/pterodactyl/yolks:java_17",
-        "Java 21": "ghcr.io/pterodactyl/yolks:java_21",
-        "Java 8": "ghcr.io/pterodactyl/yolks:java_8"
+        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
+        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
+        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
+        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
+        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
+        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:+UnlockExperimentalVMOptions -XX:+ParallelRefProcEnabled -XX:+AlwaysPreTouch -XX:MaxInlineLevel=15 -jar {{SERVER_JARFILE}}",

--- a/proxy/java/velocity/egg-velocity.json
+++ b/proxy/java/velocity/egg-velocity.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PLCN_v3",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/java/velocity/egg-velocity.json"
     },
     "exported_at": "2026-03-01T22:52:40+00:00",
     "name": "Velocity",
@@ -17,11 +17,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 21": "ghcr.io/pterodactyl/yolks:java_21",
-        "Java 17": "ghcr.io/pterodactyl/yolks:java_17",
-        "Java 16": "ghcr.io/pterodactyl/yolks:java_16",
-        "Java 11": "ghcr.io/pterodactyl/yolks:java_11",
-        "Java 8": "ghcr.io/pterodactyl/yolks:java_8"
+        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
+        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
+        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
+        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
+        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
+        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/proxy/java/velocity/egg-velocity.json
+++ b/proxy/java/velocity/egg-velocity.json
@@ -17,12 +17,12 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 8": "ghcr.io/parkervcp/yolks:java_8",
-        "Java 11": "ghcr.io/parkervcp/yolks:java_11",
-        "Java 16": "ghcr.io/parkervcp/yolks:java_16",
-        "Java 17": "ghcr.io/parkervcp/yolks:java_17",
-        "Java 21": "ghcr.io/parkervcp/yolks:java_21",
-        "Java 25": "ghcr.io/parkervcp/yolks:java_25"
+        "Java 8": "ghcr.io/pelican-eggs/yolks:java_8",
+        "Java 11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "Java 16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "Java 17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "Java 21": "ghcr.io/pelican-eggs/yolks:java_21",
+        "Java 25": "ghcr.io/pelican-eggs/yolks:java_25"
     },
     "file_denylist": [],
     "startup_commands": {

--- a/proxy/java/viaaas/egg-pterodactyl-v-i-aaa-s.json
+++ b/proxy/java/viaaas/egg-pterodactyl-v-i-aaa-s.json
@@ -14,10 +14,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_11": "ghcr.io/parkervcp/yolks:java_11",
-        "ghcr.io/parkervcp/yolks:java_16": "ghcr.io/parkervcp/yolks:java_16",
-        "ghcr.io/parkervcp/yolks:java_17": "ghcr.io/parkervcp/yolks:java_17",
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8"
+        "ghcr.io/pelican-eggs/yolks:java_11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "ghcr.io/pelican-eggs/yolks:java_16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "ghcr.io/pelican-eggs/yolks:java_17": "ghcr.io/pelican-eggs/yolks:java_17",
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}} -sslPort={{WEBSERVER_PORT}}",

--- a/proxy/java/viaaas/egg-pterodactyl-v-i-aaa-s.json
+++ b/proxy/java/viaaas/egg-pterodactyl-v-i-aaa-s.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/java/viaaas/egg-pterodactyl-v-i-aaa-s.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:09+00:00",

--- a/proxy/java/viaaas/egg-v-i-aaa-s.json
+++ b/proxy/java/viaaas/egg-v-i-aaa-s.json
@@ -15,10 +15,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "ghcr.io\/parkervcp\/yolks:java_16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "ghcr.io\/parkervcp\/yolks:java_11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/pelican-eggs\/yolks:java_17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "ghcr.io\/pelican-eggs\/yolks:java_16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "ghcr.io\/pelican-eggs\/yolks:java_11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}} -sslPort={{WEBSERVER_PORT}}",

--- a/proxy/java/viaaas/egg-v-i-aaa-s.json
+++ b/proxy/java/viaaas/egg-v-i-aaa-s.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/java/viaaas/egg-v-i-aaa-s.json"
     },
     "exported_at": "2024-06-01T19:40:09+00:00",
     "name": "VIAaaS",

--- a/proxy/java/viaproxy/egg-pterodactyl-via-proxy.json
+++ b/proxy/java/viaproxy/egg-pterodactyl-via-proxy.json
@@ -14,9 +14,9 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 22": "ghcr.io\/parkervcp\/yolks:java_22",
-        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 22": "ghcr.io\/pelican-eggs\/yolks:java_22",
+        "Java 25": "ghcr.io\/pelican-eggs\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}} cli",

--- a/proxy/java/viaproxy/egg-pterodactyl-via-proxy.json
+++ b/proxy/java/viaproxy/egg-pterodactyl-via-proxy.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/java/viaproxy/egg-pterodactyl-via-proxy.json"
     },
     "exported_at": "2025-06-01T07:53:01+00:00",
     "name": "ViaProxy",
@@ -15,7 +15,8 @@
     ],
     "docker_images": {
         "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 22": "ghcr.io\/parkervcp\/yolks:java_22"
+        "Java 22": "ghcr.io\/parkervcp\/yolks:java_22",
+        "Java 25": "ghcr.io\/parkervcp\/yolks:java_25"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}} cli",
@@ -41,7 +42,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|regex:\/^([\\w\\d._-]+)(\\.jar)$\/",
-            "field_type": "text"            
+            "field_type": "text"
         },
         {
             "name": "ViaProxy Version",
@@ -51,7 +52,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required",
-            "field_type": "text"            
+            "field_type": "text"
         }
     ]
 }

--- a/proxy/java/viaproxy/egg-via-proxy.json
+++ b/proxy/java/viaproxy/egg-via-proxy.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PLCN_v1",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/java/viaproxy/egg-via-proxy.json"
     },
     "exported_at": "2025-06-01T07:53:01+00:00",
     "name": "ViaProxy",

--- a/proxy/java/viaproxy/egg-via-proxy.json
+++ b/proxy/java/viaproxy/egg-via-proxy.json
@@ -16,8 +16,8 @@
         "pid_limit"
     ],
     "docker_images": {
-        "Java 21": "ghcr.io\/parkervcp\/yolks:java_21",
-        "Java 22": "ghcr.io\/parkervcp\/yolks:java_22"
+        "Java 21": "ghcr.io\/pelican-eggs\/yolks:java_21",
+        "Java 22": "ghcr.io\/pelican-eggs\/yolks:java_22"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}} cli",

--- a/proxy/java/waterfall/egg-pterodactyl-waterfall.json
+++ b/proxy/java/waterfall/egg-pterodactyl-waterfall.json
@@ -14,10 +14,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8",
-        "ghcr.io/parkervcp/yolks:java_11": "ghcr.io/parkervcp/yolks:java_11",
-        "ghcr.io/parkervcp/yolks:java_16": "ghcr.io/parkervcp/yolks:java_16",
-        "ghcr.io/parkervcp/yolks:java_17": "ghcr.io/parkervcp/yolks:java_17"
+        "ghcr.io/pelican-eggs/yolks:java_8": "ghcr.io/pelican-eggs/yolks:java_8",
+        "ghcr.io/pelican-eggs/yolks:java_11": "ghcr.io/pelican-eggs/yolks:java_11",
+        "ghcr.io/pelican-eggs/yolks:java_16": "ghcr.io/pelican-eggs/yolks:java_16",
+        "ghcr.io/pelican-eggs/yolks:java_17": "ghcr.io/pelican-eggs/yolks:java_17"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/proxy/java/waterfall/egg-pterodactyl-waterfall.json
+++ b/proxy/java/waterfall/egg-pterodactyl-waterfall.json
@@ -1,7 +1,7 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/java/waterfall/egg-pterodactyl-waterfall.json",
         "version": "PTDL_v2"
     },
     "exported_at": "2024-06-01T19:40:11+00:00",
@@ -14,10 +14,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io/pterodactyl/yolks:java_11": "ghcr.io/pterodactyl/yolks:java_11",
-        "ghcr.io/pterodactyl/yolks:java_16": "ghcr.io/pterodactyl/yolks:java_16",
-        "ghcr.io/pterodactyl/yolks:java_17": "ghcr.io/pterodactyl/yolks:java_17",
-        "ghcr.io/pterodactyl/yolks:java_8": "ghcr.io/pterodactyl/yolks:java_8"
+        "ghcr.io/parkervcp/yolks:java_8": "ghcr.io/parkervcp/yolks:java_8",
+        "ghcr.io/parkervcp/yolks:java_11": "ghcr.io/parkervcp/yolks:java_11",
+        "ghcr.io/parkervcp/yolks:java_16": "ghcr.io/parkervcp/yolks:java_16",
+        "ghcr.io/parkervcp/yolks:java_17": "ghcr.io/parkervcp/yolks:java_17"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/proxy/java/waterfall/egg-waterfall.json
+++ b/proxy/java/waterfall/egg-waterfall.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": null
+        "update_url": "https://raw.githubusercontent.com/pelican-eggs/minecraft/refs/heads/main/proxy/java/waterfall/egg-waterfall.json"
     },
     "exported_at": "2024-06-01T19:40:11+00:00",
     "name": "Waterfall",
@@ -15,10 +15,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/pterodactyl\/yolks:java_17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "ghcr.io\/pterodactyl\/yolks:java_16": "ghcr.io\/pterodactyl\/yolks:java_16",
-        "ghcr.io\/pterodactyl\/yolks:java_11": "ghcr.io\/pterodactyl\/yolks:java_11",
-        "ghcr.io\/pterodactyl\/yolks:java_8": "ghcr.io\/pterodactyl\/yolks:java_8"
+        "ghcr.io\/parkervcp\/yolks:java_17": "ghcr.io\/parkervcp\/yolks:java_17",
+        "ghcr.io\/parkervcp\/yolks:java_16": "ghcr.io\/parkervcp\/yolks:java_16",
+        "ghcr.io\/parkervcp\/yolks:java_11": "ghcr.io\/parkervcp\/yolks:java_11",
+        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",

--- a/proxy/java/waterfall/egg-waterfall.json
+++ b/proxy/java/waterfall/egg-waterfall.json
@@ -15,10 +15,10 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_17": "ghcr.io\/parkervcp\/yolks:java_17",
-        "ghcr.io\/parkervcp\/yolks:java_16": "ghcr.io\/parkervcp\/yolks:java_16",
-        "ghcr.io\/parkervcp\/yolks:java_11": "ghcr.io\/parkervcp\/yolks:java_11",
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/pelican-eggs\/yolks:java_17": "ghcr.io\/pelican-eggs\/yolks:java_17",
+        "ghcr.io\/pelican-eggs\/yolks:java_16": "ghcr.io\/pelican-eggs\/yolks:java_16",
+        "ghcr.io\/pelican-eggs\/yolks:java_11": "ghcr.io\/pelican-eggs\/yolks:java_11",
+        "ghcr.io\/pelican-eggs\/yolks:java_8": "ghcr.io\/pelican-eggs\/yolks:java_8"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",


### PR DESCRIPTION
# Description

A lot of eggs have inconsistencies so I have used a script to update these eggs. Therefore these haven't all been exported from the panel but a handful I selected have worked without issues. It will be clear that changes are minimal so don't need to be rigorously tested.

- A lot of eggs were missing an `update_url` so I have filled these in.
- A lot of eggs used the old "pterodactyl" yolk url so I have updated these.
- A lot of eggs were missing Java 25 which is required in 26.1, added these to those who are likely to need it (Fabric, Forge, Vanilla etc)

This PR does clash with #114 

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/pelican-eggs/minecraft/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

<!-- If this is an egg update fill these out -->

* [ ] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [ ] The egg was exported from the panel
